### PR TITLE
Add dotfiles recommender skill and update PR flow

### DIFF
--- a/.codex/skills/dotfiles-pr-flow/SKILL.md
+++ b/.codex/skills/dotfiles-pr-flow/SKILL.md
@@ -1,60 +1,62 @@
 ---
 name: dotfiles-pr-flow
-description: Dotfiles pull request workflow from local changes through shellcheck, commit, push, and gh pr create. Use when preparing a PR for this dotfiles repo and you need the exact sequence and repo-specific rules from AGENTS.md.
+description: DotfilesリポジトリのPR作成フローを、ローカル変更の整理からShellCheck・コミット・push・gh pr createまで、AGENTS.mdのルールに従って実行する必要があるときに使う。dotfiles向けのPR手順や必須ルールを正確に踏む依頼で使用する。
 ---
 
 # Dotfiles PR Flow
 
 ## Overview
 
-Follow the repo-specific PR flow: create a branch if missing, make changes, run required checks, commit with rules, push, and open a PR with the required footer.
+dotfilesリポジトリ固有のPR手順に従い、ブランチ作成、変更、チェック、コミット、push、PR作成までを順に行う。
 
 ## Workflow
 
 ### 1) Confirm scope and repo rules
 
-- Read `AGENTS.md` from the repo root and apply its PR, ShellCheck, and commit rules.
-- Assume one commit per PR unless there is a clear reason to split.
+- リポジトリ直下の `AGENTS.md` を読み、PR/ShellCheck/コミット規約を適用する。
+- 明確な理由がない限り、1 PR = 1 commit とする。
 
 ### 2) Create a branch if missing
 
-- If no branch exists yet, create one with a meaningful name.
+- ブランチが無ければ作成する。
+- 命名は `fix/yyyymm` / `vk/<slug>` / `chore/<slug>` を使う。迷う場合はユーザーに確認する。
+- 既存の作業ツリーが汚れていて分離が必要なら、別worktreeで作業する。
 
 ### 3) Make changes
 
-- Edit files as requested.
-- Keep changes minimal and focused on the requested task.
+- 依頼されたファイルのみを編集する。
+- 変更は最小限に留め、タスクに集中させる。
 
 ### 4) Run required checks
 
-- If any shell scripts under `bin/` changed, run:
+- `bin/` 配下のシェルを変更した場合は必ず実行する:
   - `shellcheck bin/*.sh`
-- Keep checks minimal unless explicitly asked to run more.
+- 明示依頼がない限り、チェックは最小限にする。
 
 ### 5) Commit (rules apply)
 
-- Use an English commit message.
-- If commit signing hangs, run:
+- コミットメッセージは英語にする。
+- 署名がハングする場合は次を実行する:
   - `export GPG_TTY=$(tty)`
-  - Ensure pinentry is configured (macOS: pinentry-mac + gpg-agent.conf).
-- Example:
+  - pinentry設定を確認（macOS: pinentry-mac + gpg-agent.conf）。
+- 例:
   - `git add <user-specified files>`
   - `git commit -m "<English summary>"`
 
 ### 6) Push
 
-- Push the branch to origin:
-  - `git push -u origin <branch>`
+- `git push -u origin <branch>` を実行する。
 
 ### 7) Create PR
 
-- After committing, confirm with the user before creating a PR.
-- Use `gh pr create` only after user confirmation.
-- Include an AI disclosure footer at the end of the PR body by default.
-  - Default line: `AI disclosure: Drafted with Codex.`
-- Prefer `--body-file` to avoid newline/markdown issues.
+- コミット後、PR作成は必ずユーザー確認を取る。
+- 確認後に `gh pr create` を実行する。
+- PR本文の末尾にAI開示文を入れる（デフォルト）:
+  - `AI disclosure: Drafted with Codex.`
+- 変更がスキル由来の場合はSummaryに1行入れる（例: `Created via dotfiles-recommender skill`）。
+- 改行崩れ回避のため `--body-file` を優先する。
 
-Example PR body (ensure the AI disclosure line is last):
+PR本文例（AI開示は末尾）:
 
 ```
 ## Summary
@@ -66,10 +68,10 @@ Example PR body (ensure the AI disclosure line is last):
 AI disclosure: Drafted with Codex.
 ```
 
-If updating PR text later, use:
+PR本文の更新は次で行う:
 - `gh pr edit --body-file <file>`
 
 ## Notes
 
-- If a user requests an AI disclosure in commit messages, add a final line in the commit message.
-- Keep the flow linear: change -> shellcheck (if needed) -> commit -> push -> PR.
+- コミットメッセージにもAI開示を要求された場合は、末尾に1行追加する。
+- フローは必ず「変更 →（必要ならShellCheck）→ commit → push → PR」の順で進める。

--- a/.codex/skills/dotfiles-recommender/SKILL.md
+++ b/.codex/skills/dotfiles-recommender/SKILL.md
@@ -50,7 +50,8 @@ Dotfilesリポジトリをレビューし、Brewfile.*と.zshrcを起点に改�
 
 ### 4) Apply and PR
 
-- 実装依頼を受けたら `dotfiles-pr-flow` を使ってPRまで進める。
+- 変更提案が採用されたら `dotfiles-pr-flow` を**呼び出して**PR作成フローに移譲する。
+- PR手順の詳細はこのスキルで繰り返さず、`dotfiles-pr-flow` に従う。
 - PR本文のSummaryに「Created via dotfiles-recommender skill」を1行追加する（AI disclosureは末尾）。
 - 作業後は作成したworktreeの削除と `git worktree prune` を行う。
 

--- a/.codex/skills/dotfiles-recommender/SKILL.md
+++ b/.codex/skills/dotfiles-recommender/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: dotfiles-recommender
+description: Dotfiles改善提案、Brewfile.*と.zshrcを中心にリポ全体を点検し、より良いアプリ/仕組み/設定値の提案や見直し点を提示する必要があるときに使う。BrewfileやZsh設定のレビュー、改善案作成、提案リスト整理、リスク区分、適用手順提示が必要な依頼で使用する。
+---
+
+# Dotfiles Recommender
+
+## Overview
+
+Dotfilesリポジトリをレビューし、Brewfile.*と.zshrcを起点に改善点や提案を整理して提示する。変更は依頼があるまで行わず、提案の根拠と影響範囲を明確にする。
+
+## Workflow
+
+### 0) Preflight
+
+- 作業前に `git status -sb` を確認し、既存の変更や未追跡が多い場合は**別worktree**で作業を分離する。
+- ブランチ名は `fix/yyyymm` / `vk/<slug>` / `chore/<slug>` のいずれかにする。迷う場合はユーザーに確認する。
+
+### 1) Scope and inputs
+
+- 対象ファイルを列挙する: `Brewfile.*`、ルートの`.zshrc`、`config/`配下、`bin/`配下。
+- 目的OSを確認する（macOS / Linux / 両方）。不明なら確認質問を出す。
+- 最新情報が必要なアプリ提案はWeb検索が必要になる旨を伝え、許可を取る。許可がない場合は一般的な改善案に留める。
+
+### 2) Review focus
+
+- **Brewfile.*:**
+  - 重複、用途の重なり、OS別の住み分け漏れを確認する。
+  - `tap`/`brew`/`cask`の分類や依存関係の整理余地を探す。
+  - コメントから意図が読み取れるかを確認し、必要なら補足提案を出す。
+- **.zshrc:**
+  - 起動時間に影響する設定（`compinit`、`autoload`、プラグイン読み込み順）を点検する。
+  - `PATH`順序、エイリアス衝突、条件分岐のOS差分を確認する。
+  - 変更の影響が大きい提案は「任意/要相談」に分ける。
+- **Repo全体:**
+  - `config/`で管理しているアプリ設定の抜けや重複を確認する。
+  - `bin/`のスクリプト品質や古い記述の改善余地を探す。
+  - READMEやAGENTS.mdの運用ルールと整合しているかを確認する。
+
+### 3) Output format
+
+- 提案は次の3区分で整理する: **Quick wins**, **Optional upgrades**, **Risky changes**。
+- 各提案に以下を明記する:
+  - 対象ファイル
+  - 提案内容（具体的な変更案）
+  - 根拠（なぜ良いか）
+  - 影響範囲（壊れる可能性や注意点）
+  - 適用手順（コマンドや差分例）
+- 変更実装を求められたら、最小限の変更に留め、必要ならテスト/チェック（例: `shellcheck bin/*.sh`）を案内する。
+
+### 4) Apply and PR
+
+- 実装依頼を受けたら `dotfiles-pr-flow` を使ってPRまで進める。
+- PR本文のSummaryに「Created via dotfiles-recommender skill」を1行追加する（AI disclosureは末尾）。
+- 作業後は作成したworktreeの削除と `git worktree prune` を行う。
+
+## Guidance
+
+- 具体的な提案が難しい場合は、質問を返して前提を固める。
+- ベストプラクティスの押し付けではなく、現状の意図を尊重した代替案として提示する。
+- 不確実な提案には「仮説」や「要検証」を明記する。


### PR DESCRIPTION
## Summary
- Add dotfiles-recommender skill
- Update dotfiles-pr-flow instructions (Japanese + branch/worktree rules)
- Handoff PR steps to dotfiles-pr-flow from dotfiles-recommender
- Created via dotfiles-recommender skill

## Testing
- Not run (not requested)

AI disclosure: Drafted with Codex.
