### PR TITLE
Guard chpwd() to skip in non-interactive shells

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -162,6 +162,7 @@ lg() {
 }
 
 chpwd() {
+  [[ -o interactive ]] || return
   ll
 }
 

--- a/bin/ci_zsh_loading_test.sh
+++ b/bin/ci_zsh_loading_test.sh
@@ -14,13 +14,18 @@ run_zsh() {
   local cmd="source \"$ZDOTDIR/.zshrc\"; $*"
   if command -v script >/dev/null 2>&1; then
     # Allocate a pseudo-tty so zle widgets can initialize in CI.
+    # Try Linux util-linux syntax (options before file).
+    if script -q -c "true" /dev/null </dev/null >/dev/null 2>&1; then
+      script -q -c "env CI= $ZSH_BIN -ic \"$cmd\"" /dev/null 2>&1
+      return
+    fi
+    # Try older Linux / macOS syntax.
     if script -q /dev/null -c "true" </dev/null >/dev/null 2>&1; then
       script -q /dev/null -c "env CI= $ZSH_BIN -ic \"$cmd\"" 2>&1
-    else
-      script -q /dev/null env CI= "$ZSH_BIN" -ic "$cmd" 2>&1
+      return
     fi
-    return
   fi
+  # Fallback: no pseudo-tty (zle warnings are harmless).
   env CI= "$ZSH_BIN" -ic "$cmd" 2>&1
 }
 


### PR DESCRIPTION
## Summary
- `chpwd()` 内に `[[ -o interactive ]] || return` ガードを追加
- 非インタラクティブシェル（スクリプト実行時など）で `ll` が実行されてしまう問題を防止

## Background
Claude Code が `cd && <command>` のようなBashコマンドを実行すると、`chpwd()` フックが発火して `ll` (プロセス生成を伴うコマンド) が実行される。Claude Code は非インタラクティブシェルでコマンドを実行するが、この場合 `chpwd()` 内で生成されたプロセスの終了を正しく検知できず、コマンドがハングアップするバグがある。

ref: https://github.com/anthropics/claude-code/issues/3505#issuecomment-3861970389

## Fix
`[[ -o interactive ]] || return` ガードを `chpwd()` の先頭に追加し、非インタラクティブシェルでは `ll` を実行しないようにした。これにより Claude Code の Bash ツール経由での `cd` を含むコマンド実行時のハングアップを回避できる。

## Test plan
- [x] インタラクティブシェルで `cd` 時に `ll` が実行されることを確認
- [x] スクリプト内での `cd` で `ll` が実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
