### PR TITLE
Update ghostty theme and disable starship golang module

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,4 +1,4 @@
-theme = Builtin Solarized Dark
+theme = Iterm2 Solarized Dark
 command = /bin/zsh -l -c "/opt/homebrew/bin/tmux new -A -s ghostty"
 font-feature = -calt, -liga, -dlig
 font-thicken = true

--- a/config/starship.toml
+++ b/config/starship.toml
@@ -96,6 +96,9 @@ disabled = true
 [nodejs]
 disabled = true
 
+[golang]
+disabled = true
+
 [docker_context]
 disabled = true
 


### PR DESCRIPTION
## Summary
- Ghostty テーマを `Builtin Solarized Dark` → `Iterm2 Solarized Dark` に変更
- Starship の golang モジュールを無効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)