### PR TITLE
ci: bump actions to Node 24 versions and fix cache-save warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   static_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install check tools (zsh, yq, gitleaks)
@@ -36,11 +36,11 @@ jobs:
   zsh_loading_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Homebrew cache
         id: cache-brew
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             /opt/homebrew
@@ -55,8 +55,10 @@ jobs:
         run: SKIP_BREW=1 ./bin/mkworld.sh
 
       - name: Save Homebrew cache
-        if: always()
-        uses: actions/cache/save@v4
+        # Only save on a cache miss; saving on a hit re-uses the same key and
+        # fails with "Cache already exists" (harmless warning).
+        if: always() && steps.cache-brew.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
         with:
           path: |
             /opt/homebrew


### PR DESCRIPTION
## Summary

Clears the 3 warnings shown in the CI run annotations. CI was already green; these are non-blocking, but the Node 20 one will eventually become a hard error once GitHub stops force-running deprecated actions.

- **Node.js 20 deprecation**: bump `actions/checkout` and `actions/cache/{restore,save}` from `v4` → `v5` (v4 targets Node 20; v5 runs on Node 24).
- **"Cache save failed"**: the save step ran with `if: always()`, so on a cache hit it tried to re-save under the same key and warned "Cache already exists". Now it only saves on a cache miss (`steps.cache-brew.outputs.cache-hit != 'true'`).

## Test

- `./bin/lint_config.sh` (CI config-syntax equivalent, yq YAML validation) passes.
- lefthook pre-commit (config-syntax / gitleaks / secret-files) and commit-msg (conventional) hooks passed on commit.
- Functional verification happens on this PR's own CI run — the annotations should drop to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
