### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   static_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - name: Install check tools (zsh, yq, gitleaks)
@@ -36,11 +36,11 @@ jobs:
   zsh_loading_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Restore Homebrew cache
         id: cache-brew
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             /opt/homebrew
@@ -58,7 +58,7 @@ jobs:
         # Only save on a cache miss; saving on a hit re-uses the same key and
         # fails with "Cache already exists" (harmless warning).
         if: always() && steps.cache-brew.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             /opt/homebrew


### PR DESCRIPTION
## Summary

Follow-up to #14. Pin third-party actions to immutable commit SHAs instead of mutable tags, as supply-chain hardening — a tag like `v5` can be re-pointed (force-pushed) to malicious code, while a full SHA cannot. The `# v5` trailing comment keeps it human-readable and lets tools (Dependabot/Renovate) still track the version.

| action | pinned to |
|--------|-----------|
| `actions/checkout` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5` |
| `actions/cache/restore` | `27d5ce7f107fe9357f9df03efb73ab90386fccae # v5` |
| `actions/cache/save` | `27d5ce7f107fe9357f9df03efb73ab90386fccae # v5` |

(`cache/restore` and `cache/save` share the same SHA since both are subpaths of the `actions/cache` repo.)

## Test

- `./bin/lint_config.sh` (CI config-syntax equivalent, yq YAML validation) passes.
- lefthook pre-commit (config-syntax / gitleaks / secret-files) and commit-msg (conventional) hooks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
