### PR TITLE
ci: enforce GitHub Actions SHA pinning (ratchet) + auto-update (dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions fresh: Dependabot bumps each pin to the
+  # newest commit SHA and updates the trailing "# vX" version comment. ratchet
+  # (bin/lint_actions.sh) enforces that everything stays pinned; this keeps the
+  # pins from going stale.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Let a new release age before proposing it, so a freshly-published
+    # (possibly compromised) version is not pulled in immediately.
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,15 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
-      - name: Install check tools (zsh, yq, gitleaks)
+      - name: Install check tools (zsh, yq, gitleaks, ratchet)
         run: |
           set -e
           sudo apt-get update -qq
           sudo apt-get install -y zsh
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gitleaks
+          curl -sSfL https://github.com/sethvargo/ratchet/releases/download/v0.11.4/ratchet_0.11.4_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin ratchet
           sudo curl -sSfL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
       - name: Lint shell scripts
@@ -26,6 +28,8 @@ jobs:
         run: ./bin/lint_zsh.sh
       - name: Validate config files
         run: ./bin/lint_config.sh
+      - name: Check action pinning (ratchet)
+        run: ./bin/lint_actions.sh
       - name: Check Brewfile sort
         run: ./bin/check_brewfile_sort.sh
       - name: Check for sensitive filenames

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -83,6 +83,8 @@ brew "nmap"
 brew "openvpn"
 # Generic machine emulator and virtualizer
 brew "qemu"
+# Pin/lint GitHub Actions workflows to immutable commit SHAs
+brew "ratchet"
 # Persistent key-value database, with built-in net interface
 brew "redis"
 # Wrapper around ripgrep that adds multiple rich file types

--- a/bin/lint_actions.sh
+++ b/bin/lint_actions.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Verify every GitHub Actions `uses:` in our workflows is pinned to a full
+# commit SHA (not a mutable tag). Single source of truth shared by CI and the
+# lefthook pre-commit hook. ratchet only applies to .github/workflows, so all
+# workflow files are checked regardless of arguments.
+
+set -euo pipefail
+
+BASE_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." || exit 1; pwd)
+cd "$BASE_DIR" || exit 1
+
+if ! command -v ratchet >/dev/null 2>&1; then
+    echo "x ratchet not found; install it (brew install ratchet)" >&2
+    exit 1
+fi
+
+files=()
+while IFS= read -r f; do
+    files+=("$f")
+done < <(git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml')
+
+[ "${#files[@]}" -eq 0 ] && exit 0
+
+ratchet lint "${files[@]}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,6 +21,11 @@ pre-commit:
         - "*.yaml"
         - "*.yml"
       run: ./bin/lint_config.sh {staged_files}
+    action-pinning:
+      glob:
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+      run: ./bin/lint_actions.sh
     brewfile-sort:
       glob: "Brewfile.*"
       run: ./bin/check_brewfile_sort.sh


### PR DESCRIPTION
## Summary

Follow-up to #15. Makes the SHA pinning self-sustaining so future workflow edits can't silently regress, and the pins don't go stale.

**A. Enforce (ratchet)** — fail if any `uses:` is not pinned to a full commit SHA:
- `bin/lint_actions.sh`: runs `ratchet lint` over `.github/workflows/*`. Works offline (no upstream API calls), so it is safe in both CI and the pre-commit hook.
- `lefthook.yml`: new `action-pinning` pre-commit check (glob-scoped to workflow files).
- `.github/workflows/ci.yml`: install ratchet and add a "Check action pinning" step in `static_checks` — same single-source-of-truth scripts in CI and hooks.
- `Brewfile.common`: add `ratchet` (A-Z sorted) so the local hook has the binary.

**B. Auto-update (dependabot)** — keep the pins fresh:
- `.github/dependabot.yml`: weekly `github-actions` updates. Dependabot bumps each SHA pin to the newest commit and updates the trailing `# vX` comment, so ratchet's "must be pinned" rule and freshness coexist.

## Test

- `./bin/lint_actions.sh` passes on the current (SHA-pinned) workflow; a negative test with `actions/checkout@v5` (tag) correctly fails with "Unpinned reference".
- `lint_shell.sh` / `lint_config.sh` (validates `dependabot.yml`) / `check_brewfile_sort.sh` all pass.
- lefthook pre-commit (incl. the new `action-pinning` check) and commit-msg hooks passed on commit.

## Notes

- Uses `ratchet lint` (not the deprecated `ratchet check`).
- ratchet pinned in CI to release `v0.11.4`; the tarball ships the `ratchet` binary at root (same install pattern as gitleaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
