### PR TITLE
feat(tmux): improve scrollbar style, copy-mode selection color, and default attach

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -35,10 +35,11 @@ setw -g automatic-rename-format '#{?#{&&:#{==:#{window_panes},1},#{!=:#{pane_tit
 setw -g allow-rename off
 set -g mouse on
 set -g history-limit 50000
+set -g default-client-command attach
 
 # tmux 3.6+: スクロールバー（古い tmux では無視）
 if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 6 ]; }' \
-  "set -g pane-scrollbars on"
+  "set -g pane-scrollbars on; set -g pane-scrollbars-position right; set -g pane-scrollbars-style 'fg=#2aa198'"
 set -g default-terminal "xterm-256color"
 set -as terminal-features '*:RGB'
 set -as terminal-features '*:hyperlinks'
@@ -96,6 +97,7 @@ set-option -g pane-border-format " ###{pane_index}: #{?#{==:#{pane_title},#{host
 set-option -g pane-border-lines heavy
 set-option -g pane-border-style "fg=#2c4a52"
 set-option -g pane-active-border-style "fg=#2aa198"
+set -g copy-mode-selection-style "bg=#2aa198,fg=#002b36"
 set-option -g window-style "bg=default"
 set-option -g window-active-style "bg=default"
 


### PR DESCRIPTION
## Summary

- Add `pane-scrollbars-position right` and `pane-scrollbars-style 'fg=#2aa198'` to match Solarized teal theme
- Add `copy-mode-selection-style` with matching teal background/foreground colors
- Add `default-client-command attach` so new tmux clients auto-attach to an existing session

## Test plan

- [x] Reload tmux config (`tmux source ~/.tmux.conf`) and verify no parse errors
- [x] Confirm scrollbar appears on the right with teal color (tmux 3.6+ only)
- [x] Confirm copy-mode selection highlight uses teal colors
- [x] Confirm `tmux` command auto-attaches when a session already exists

🤖 Generated with [Claude Code](https://claude.ai/claude-code)