### PR TITLE
feat(tmux): add tmux-fzf for fuzzy window/session search

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -53,6 +53,7 @@ set -g @tpm_plugins ' \
   tmux-plugins/tmux-continuum \
   jaclu/tmux-menus \
   laktak/extrakto \
+  sainnhe/tmux-fzf \
   nhdaly/tmux-better-mouse-mode \
   alexwforsythe/tmux-which-key \
   timvw/tmux-assistant-resurrect \


### PR DESCRIPTION
## What

Adds [`sainnhe/tmux-fzf`](https://github.com/sainnhe/tmux-fzf) to the TPM plugin list — a fuzzy finder for tmux windows, sessions and panes.

## Why

I currently run a single session with ~10 windows and switch by number (`M-1..9`). This adds a way to **jump to any window by name** instead of remembering its number.

## Behavior

- Press **`prefix + F`** → an fzf menu opens (window / session / pane / command / keybinding) with preview.
- Pick `window`, type part of the name, hit enter → switch there. Can also rename/kill/move, and multi-select with TAB.

## Why this is low-risk (purely additive)

- **No existing binding uses `F`** (verified) — no conflicts.
- Existing keybindings (`M-1..9`, `M`, extrakto, etc.) are **untouched**.
- Only change is one line in the `@tpm_plugins` list.
- Prereqs already satisfied: tmux ≥ 3.2 (popup) and fzf are both installed.

## Verification

Loaded `.tmux.conf` before/after this change on tmux 3.4 and confirmed the **config-error set is identical** — the new `@tpm_plugins` entry introduces no new load errors. (The two pre-existing `invalid option` lines are unrelated 3.6-only options already on `main`.)

## After merge

On the machine, run `prefix + I` once so TPM installs the plugin. Then `prefix + F` is live.

> Note: default action order can be tweaked to put `window` first via `TMUX_FZF_ORDER` if desired — left out here to keep the change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRKXK1No1q6wfN3AmVFXDb)_