### PR TITLE
fix(tmux): guard 3.6-only options so config loads on older tmux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -35,11 +35,10 @@ setw -g automatic-rename-format '#{?#{&&:#{==:#{window_panes},1},#{!=:#{pane_tit
 setw -g allow-rename off
 set -g mouse on
 set -g history-limit 50000
-set -g default-client-command attach
 
-# tmux 3.6+: スクロールバー（古い tmux では無視）
+# tmux 3.6+ のみ適用（古い tmux では unknown option を避けるためスキップ）
 if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 6 ]; }' \
-  "set -g pane-scrollbars on; set -g pane-scrollbars-position right; set -g pane-scrollbars-style 'fg=#2aa198'"
+  "set -g default-client-command attach; set -g pane-scrollbars on; set -g pane-scrollbars-position right; set -g pane-scrollbars-style 'fg=#2aa198'"
 set -g default-terminal "xterm-256color"
 set -as terminal-features '*:RGB'
 set -as terminal-features '*:hyperlinks'
@@ -97,7 +96,9 @@ set-option -g pane-border-format " ###{pane_index}: #{?#{==:#{pane_title},#{host
 set-option -g pane-border-lines heavy
 set-option -g pane-border-style "fg=#2c4a52"
 set-option -g pane-active-border-style "fg=#2aa198"
-set -g copy-mode-selection-style "bg=#2aa198,fg=#002b36"
+# tmux 3.6+ のみ適用（古い tmux では unknown option を避けるためスキップ）
+if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 6 ]; }' \
+  'set -g copy-mode-selection-style "bg=#2aa198,fg=#002b36"'
 set-option -g window-style "bg=default"
 set-option -g window-active-style "bg=default"
 


### PR DESCRIPTION
## Problem

`default-client-command` and `copy-mode-selection-style` are **tmux 3.6+ only** options, but on `main` they were set unconditionally. Loading `.tmux.conf` on tmux < 3.6 therefore fails with:

```
invalid option: default-client-command
invalid option: copy-mode-selection-style
```

The existing `pane-scrollbars` block was already guarded by a version check — these two were just missed when added in the recent tmux overhaul.

## Fix

Move both options behind the same `if-shell` tmux-version guard:
- `default-client-command` → folded into the adjacent existing 3.6 guard block.
- `copy-mode-selection-style` → wrapped in its own guard in place (kept after-tpm so it still overrides plugin defaults).

## Verification (on tmux 3.4)

| | before | after |
|---|---|---|
| config errors on load | 2 (`invalid option …`) | **0** ✅ |
| guarded options on 3.4 | — | correctly **skipped** |

Guard logic checked across versions: `3.4 → skip`, `3.5a → skip`, `3.6b → apply`, `4.0 → apply`. On tmux ≥ 3.6 behaviour is unchanged (options still applied).

## Why it matters

Keeps the config loading cleanly on older tmux (remote servers, distro packages, this repo's CI runner at 3.4) instead of erroring at startup. No effect for anyone already on tmux 3.6+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRKXK1No1q6wfN3AmVFXDb)_