### PR TITLE
feat(github): add PR template and block direct commits to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Keep this PR small and focused. Prefer 1 commit per PR.
+Commit subjects must follow Conventional Commits (enforced by lefthook):
+  type(scope): description   type ∈ {feat, fix, chore, docs, refactor, ci}
+-->
+
+## Summary
+
+<!-- What does this PR change and why? 1-3 sentences. -->
+
+## Changes
+
+<!-- Bullet list of the concrete changes. -->
+-
+
+## Type
+
+<!-- Check all that apply. Must match the commit type. -->
+- [ ] feat — new functionality
+- [ ] fix — bug fix
+- [ ] chore — tooling / maintenance
+- [ ] docs — documentation only
+- [ ] refactor — no behavior change
+- [ ] ci — CI / workflow
+
+## Verification
+
+<!-- How was this checked? -->
+- [ ] `lefthook run pre-commit` passes locally (lint, config, secrets)
+- [ ] CI is green
+- [ ] Manually verified the affected dotfile(s) load
+
+## Checklist
+
+- [ ] Branched off `main` — no direct commits to `main`
+- [ ] Commit subjects follow Conventional Commits
+- [ ] No secrets / sensitive files committed (gitleaks clean)
+
+## Related
+
+<!-- Closes #123, refs #456, or "none". -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@
 - Set `ZDOTDIR` to the repo root when running CI zsh checks.
 - To skip parts of `.zshrc` in CI, use a dedicated env flag — not an early return.
 
+### Branch & PR workflow
+- Never commit or push directly to `main`. Always branch: `git switch -c <type>/<short-desc>` (type ∈ feat|fix|chore|docs|refactor|ci).
+- lefthook blocks direct commits/pushes to `main` (`protect-main` in pre-commit & pre-push); GitHub branch protection enforces it server-side too.
+- Every change lands via a PR using `.github/PULL_REQUEST_TEMPLATE.md` — fill in Summary, Changes, Type (matching the commit type), Verification, and the checklist.
+- Keep PRs small: prefer 1 commit per PR; commit subject must satisfy the Conventional Commits check.
+
 ### PR updates
 - Use `gh pr edit --body-file` to avoid newline/markdown issues.
 - Claude Code auto-appends `🤖 Generated with Claude Code` to PR bodies and `Co-Authored-By: Claude ...` to commits — do not remove these.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,19 @@
 pre-commit:
   parallel: true
   commands:
+    # Block direct commits to main: work happens on feature branches + PRs.
+    # GitHub branch protection is the server-side enforcement; this is the
+    # fast local feedback. Bypass intentionally with: git commit --no-verify
+    protect-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+          echo "x Direct commits to 'main' are blocked."
+          echo "  Create a feature branch and open a PR:"
+          echo "    git switch -c <type>/<short-desc>"
+          echo "  Intentional bypass: git commit --no-verify"
+          exit 1
+        fi
     shell-lint:
       glob: "bin/*.sh"
       run: ./bin/lint_shell.sh
@@ -36,6 +49,20 @@ pre-commit:
 
 pre-push:
   commands:
+    # Refuse to push anything to refs/heads/main. lefthook feeds the git
+    # pre-push stdin (each line: <local-ref> <local-sha> <remote-ref> <remote-sha>)
+    # to the command, so we can inspect exactly what is being pushed.
+    protect-main:
+      run: |
+        while read -r _ _ remote_ref _; do
+          case "$remote_ref" in
+            refs/heads/main)
+              echo "x Direct push to 'main' is blocked. Open a PR instead."
+              echo "  Intentional bypass: git push --no-verify"
+              exit 1
+              ;;
+          esac
+        done
     gitleaks-full:
       run: gitleaks git --no-banner --redact
 


### PR DESCRIPTION
Add a structured PR template that humans and AI agents can follow, and
guard against direct work on main via lefthook (pre-commit + pre-push
protect-main). Document the branch/PR workflow in AGENTS.md so agents
follow it. GitHub branch protection is the server-side counterpart.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>