### PR TITLE
chore(claude): add web SessionStart hook + shared lint toolchain installer

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,10 +2,9 @@
 # Claude Code on the web — SessionStart hook.
 #
 # Installs this dotfiles repo's dev/CI tooling into the ephemeral web sandbox so
-# the lefthook checks and bin/ lint + loading-test scripts behave the same as in
-# GitHub Actions. Without this, every fresh web session is missing zsh, yq,
-# gitleaks, ratchet, shellcheck, lefthook and tmux, so commits get blocked and
-# the lint scripts fail.
+# the lefthook checks and bin/ lint scripts behave the same as in GitHub Actions.
+# Without this, every fresh web session is missing zsh, yq, gitleaks, ratchet,
+# shellcheck and lefthook, so commits get blocked and the lint scripts fail.
 #
 # Local (non-remote) sessions are skipped — on a real machine `brew bundle` /
 # bin/mkworld.sh already set everything up.
@@ -27,11 +26,11 @@ SUDO=""
 
 log() { echo "[session-start] $*"; }
 
-# 1. apt packages: zsh (syntax check), tmux (loading test), shellcheck, fzf.
+# 1. apt packages: zsh (syntax check), shellcheck, fzf.
 if command -v apt-get >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
   $SUDO apt-get update -qq || true
-  $SUDO apt-get install -y -qq zsh tmux shellcheck fzf >/dev/null
+  $SUDO apt-get install -y -qq zsh shellcheck fzf >/dev/null
 fi
 
 # 2. mikefarah yq — config-syntax check relies on `yq -p toml|json|yaml`.
@@ -64,10 +63,4 @@ if cd "${CLAUDE_PROJECT_DIR:-$PWD}"; then
   lefthook install >/dev/null 2>&1 || true
 fi
 
-# 6. tpm — so bin/ci_tmux_loading_test.sh can load .tmux.conf as on a real machine.
-if [ ! -e "$HOME/.tmux/plugins/tpm/tpm" ]; then
-  mkdir -p "$HOME/.tmux/plugins"
-  git clone -q --depth 1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" || true
-fi
-
-log "tooling ready: zsh tmux shellcheck fzf yq gitleaks ratchet lefthook tpm"
+log "tooling ready: zsh shellcheck fzf yq gitleaks ratchet lefthook"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # Claude Code on the web — SessionStart hook.
 #
-# Installs this dotfiles repo's dev/CI tooling into the ephemeral web sandbox so
-# the lefthook checks and bin/ lint scripts behave the same as in GitHub Actions.
-# Without this, every fresh web session is missing zsh, yq, gitleaks, ratchet,
-# shellcheck and lefthook, so commits get blocked and the lint scripts fail.
+# Provisions this repo's lint toolchain in the ephemeral web sandbox so commits
+# (lefthook) and the bin/ lint scripts behave the same as in CI. The pinned tool
+# versions live in bin/install_check_tools.sh (shared with CI) — NOT duplicated
+# here.
 #
-# Local (non-remote) sessions are skipped — on a real machine `brew bundle` /
+# Local (non-remote) sessions are skipped: on a real machine `brew bundle` /
 # bin/mkworld.sh already set everything up.
 set -euo pipefail
 
@@ -15,52 +15,35 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Versions pinned to match .github/workflows/ci.yml.
-GITLEAKS_VERSION=8.30.1
-RATCHET_VERSION=0.11.4
-YQ_VERSION=4.53.2
-LEFTHOOK_VERSION=2.1.9
+REPO="${CLAUDE_PROJECT_DIR:-$PWD}"
+LEFTHOOK_VERSION="${LEFTHOOK_VERSION:-2.1.9}"
 
-SUDO=""
-[ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
 
-log() { echo "[session-start] $*"; }
+# 1. Shared lint toolchain (zsh, shellcheck, yq, gitleaks, ratchet).
+"$REPO/bin/install_check_tools.sh"
 
-# 1. apt packages: zsh (syntax check), shellcheck, fzf.
-if command -v apt-get >/dev/null 2>&1; then
-  export DEBIAN_FRONTEND=noninteractive
-  $SUDO apt-get update -qq || true
-  $SUDO apt-get install -y -qq zsh shellcheck fzf >/dev/null
-fi
-
-# 2. mikefarah yq — config-syntax check relies on `yq -p toml|json|yaml`.
-if ! { command -v yq >/dev/null 2>&1 && yq --version 2>/dev/null | grep -qi mikefarah; }; then
-  $SUDO curl -sSfL -o /usr/local/bin/yq \
-    "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-  $SUDO chmod +x /usr/local/bin/yq
-fi
-
-# 3. gitleaks — secret scanning (pre-commit + pre-push).
-if ! command -v gitleaks >/dev/null 2>&1; then
-  curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-    | $SUDO tar -xz -C /usr/local/bin gitleaks
-fi
-
-# 4. ratchet — GitHub Actions pinning check.
-if ! command -v ratchet >/dev/null 2>&1; then
-  curl -sSfL "https://github.com/sethvargo/ratchet/releases/download/v${RATCHET_VERSION}/ratchet_${RATCHET_VERSION}_linux_amd64.tar.gz" \
-    | $SUDO tar -xz -C /usr/local/bin ratchet
-fi
-
-# 5. lefthook + install the git hooks so commits run the same checks as CI.
+# 2. lefthook — git hook runner; install hooks so commits run CI's checks.
 if ! command -v lefthook >/dev/null 2>&1; then
   curl -sSfL "https://github.com/evilmartians/lefthook/releases/download/v${LEFTHOOK_VERSION}/lefthook_${LEFTHOOK_VERSION}_Linux_x86_64.gz" \
     | gunzip > /tmp/lefthook
-  $SUDO install -m 0755 /tmp/lefthook /usr/local/bin/lefthook
+  as_root install -m 0755 /tmp/lefthook /usr/local/bin/lefthook
   rm -f /tmp/lefthook
 fi
-if cd "${CLAUDE_PROJECT_DIR:-$PWD}"; then
+if cd "$REPO"; then
   lefthook install >/dev/null 2>&1 || true
 fi
 
-log "tooling ready: zsh shellcheck fzf yq gitleaks ratchet lefthook"
+# 3. fzf — used by the repo's interactive zsh helpers (g, b, livegrep, ...).
+if ! command -v fzf >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  as_root apt-get install -y -qq fzf >/dev/null || true
+fi
+
+echo "[session-start] tooling ready (bin/install_check_tools.sh + lefthook + fzf)"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Claude Code on the web — SessionStart hook.
+#
+# Installs this dotfiles repo's dev/CI tooling into the ephemeral web sandbox so
+# the lefthook checks and bin/ lint + loading-test scripts behave the same as in
+# GitHub Actions. Without this, every fresh web session is missing zsh, yq,
+# gitleaks, ratchet, shellcheck, lefthook and tmux, so commits get blocked and
+# the lint scripts fail.
+#
+# Local (non-remote) sessions are skipped — on a real machine `brew bundle` /
+# bin/mkworld.sh already set everything up.
+set -euo pipefail
+
+# Only run inside the remote web sandbox.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Versions pinned to match .github/workflows/ci.yml.
+GITLEAKS_VERSION=8.30.1
+RATCHET_VERSION=0.11.4
+YQ_VERSION=4.53.2
+LEFTHOOK_VERSION=2.1.9
+
+SUDO=""
+[ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+
+log() { echo "[session-start] $*"; }
+
+# 1. apt packages: zsh (syntax check), tmux (loading test), shellcheck, fzf.
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  $SUDO apt-get update -qq || true
+  $SUDO apt-get install -y -qq zsh tmux shellcheck fzf >/dev/null
+fi
+
+# 2. mikefarah yq — config-syntax check relies on `yq -p toml|json|yaml`.
+if ! { command -v yq >/dev/null 2>&1 && yq --version 2>/dev/null | grep -qi mikefarah; }; then
+  $SUDO curl -sSfL -o /usr/local/bin/yq \
+    "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+  $SUDO chmod +x /usr/local/bin/yq
+fi
+
+# 3. gitleaks — secret scanning (pre-commit + pre-push).
+if ! command -v gitleaks >/dev/null 2>&1; then
+  curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+    | $SUDO tar -xz -C /usr/local/bin gitleaks
+fi
+
+# 4. ratchet — GitHub Actions pinning check.
+if ! command -v ratchet >/dev/null 2>&1; then
+  curl -sSfL "https://github.com/sethvargo/ratchet/releases/download/v${RATCHET_VERSION}/ratchet_${RATCHET_VERSION}_linux_amd64.tar.gz" \
+    | $SUDO tar -xz -C /usr/local/bin ratchet
+fi
+
+# 5. lefthook + install the git hooks so commits run the same checks as CI.
+if ! command -v lefthook >/dev/null 2>&1; then
+  curl -sSfL "https://github.com/evilmartians/lefthook/releases/download/v${LEFTHOOK_VERSION}/lefthook_${LEFTHOOK_VERSION}_Linux_x86_64.gz" \
+    | gunzip > /tmp/lefthook
+  $SUDO install -m 0755 /tmp/lefthook /usr/local/bin/lefthook
+  rm -f /tmp/lefthook
+fi
+if cd "${CLAUDE_PROJECT_DIR:-$PWD}"; then
+  lefthook install >/dev/null 2>&1 || true
+fi
+
+# 6. tpm — so bin/ci_tmux_loading_test.sh can load .tmux.conf as on a real machine.
+if [ ! -e "$HOME/.tmux/plugins/tpm/tpm" ]; then
+  mkdir -p "$HOME/.tmux/plugins"
+  git clone -q --depth 1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" || true
+fi
+
+log "tooling ready: zsh tmux shellcheck fzf yq gitleaks ratchet lefthook tpm"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/bin/install_check_tools.sh
+++ b/bin/install_check_tools.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Single source of truth for the lint/check toolchain (pinned versions + install).
+# Shared by GitHub Actions CI and the Claude Code web SessionStart hook so the
+# versions live in exactly ONE place. Targets Linux (apt + GitHub release
+# binaries); on a real machine use `brew bundle` (Brewfile.*) instead.
+set -euo pipefail
+
+# The one place to bump versions (override via env if needed).
+GITLEAKS_VERSION="${GITLEAKS_VERSION:-8.30.1}"
+RATCHET_VERSION="${RATCHET_VERSION:-0.11.4}"
+YQ_VERSION="${YQ_VERSION:-4.53.2}"
+
+# Run a command as root, using sudo only when we are not already root.
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+# zsh (zsh-syntax check) + shellcheck (shell-lint) via apt.
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  as_root apt-get update -qq || true
+  as_root apt-get install -y -qq zsh shellcheck >/dev/null
+fi
+
+# mikefarah yq (config-syntax: `yq -p toml|json|yaml`).
+if ! { command -v yq >/dev/null 2>&1 && yq --version 2>/dev/null | grep -qi mikefarah; }; then
+  as_root curl -sSfL -o /usr/local/bin/yq \
+    "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+  as_root chmod +x /usr/local/bin/yq
+fi
+
+# gitleaks (secret scanning).
+if ! command -v gitleaks >/dev/null 2>&1; then
+  curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+    | as_root tar -xz -C /usr/local/bin gitleaks
+fi
+
+# ratchet (GitHub Actions pinning check).
+if ! command -v ratchet >/dev/null 2>&1; then
+  curl -sSfL "https://github.com/sethvargo/ratchet/releases/download/v${RATCHET_VERSION}/ratchet_${RATCHET_VERSION}_linux_amd64.tar.gz" \
+    | as_root tar -xz -C /usr/local/bin ratchet
+fi


### PR DESCRIPTION
## What

- Adds a **SessionStart hook** (`.claude/hooks/session-start.sh` + `.claude/settings.json`) that provisions this repo's lint toolchain in the Claude Code **web** sandbox.
- Extracts a new **`bin/install_check_tools.sh`** — a single source of truth for the pinned lint/check toolchain (versions + install), so CI and the web hook share exactly one definition instead of duplicating versions.

## Why

Each Claude Code web session starts from a fresh, toolless container. Without zsh / shellcheck / yq / gitleaks / ratchet / lefthook, commits get blocked by lefthook and the `bin/` lint scripts fail — so every session wastes time re-installing tools by hand.

Previously the version pins lived in `.github/workflows/ci.yml` only; copying them into the hook would mean two places to keep in sync. `bin/install_check_tools.sh` makes the versions live in **one** place.

## Files

- **`bin/install_check_tools.sh`** (new) — pins + installs the shared toolchain on Linux (apt + GitHub release binaries): `zsh`, `shellcheck`, mikefarah `yq` 4.53.2, `gitleaks` 8.30.1, `ratchet` 0.11.4. Idempotent (`command -v` guards), non-interactive. Overridable via env vars.
- **`.claude/hooks/session-start.sh`** (new) — web-only entrypoint: calls `bin/install_check_tools.sh`, then adds the web-specific bits on top: `lefthook` 2.1.9 + `lefthook install` (so commits run CI's checks), and `fzf` (for the repo's interactive zsh helpers).
- **`.claude/settings.json`** (new) — wires the hook into `SessionStart`.

## Safety

- **Web-only**: the hook is guarded by `CLAUDE_CODE_REMOTE` → on a real machine it exits immediately (you keep using `brew bundle` / `bin/mkworld.sh`).
- Idempotent, non-interactive, synchronous.

## Validation (run in this sandbox)

1. ✅ Hook executes cleanly (exit 0); shared installer + lefthook + fzf all present.
2. ✅ Linters: `bin/lint_shell.sh`, `bin/lint_config.sh` PASS. Both new scripts are shellcheck-clean.
3. ✅ Proof: this PR's commits passed **all lefthook pre-commit checks naturally** (no `--no-verify`) because the hook had installed the tooling.

## Follow-up (manual, not in this PR)

I can't push changes to `.github/workflows/` from this environment, so the CI side isn't wired up yet. To finish the dedup, replace the existing "Install check tools" step in the `static_checks` job of `.github/workflows/ci.yml` with:

```yaml
      - name: Install check tools
        run: ./bin/install_check_tools.sh
```

After that, CI and the web hook install from the exact same source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRKXK1No1q6wfN3AmVFXDb)_