### PR TITLE
refactor(setup): install biome in shared check-tools script

### DIFF
--- a/bin/install_check_tools.sh
+++ b/bin/install_check_tools.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 GITLEAKS_VERSION="${GITLEAKS_VERSION:-8.30.1}"
 RATCHET_VERSION="${RATCHET_VERSION:-0.11.4}"
 YQ_VERSION="${YQ_VERSION:-4.53.2}"
+BIOME_VERSION="${BIOME_VERSION:-2.5.0}"
 
 # Run a command as root, using sudo only when we are not already root.
 as_root() {
@@ -43,4 +44,11 @@ fi
 if ! command -v ratchet >/dev/null 2>&1; then
   curl -sSfL "https://github.com/sethvargo/ratchet/releases/download/v${RATCHET_VERSION}/ratchet_${RATCHET_VERSION}_linux_amd64.tar.gz" \
     | as_root tar -xz -C /usr/local/bin ratchet
+fi
+
+# biome (config-syntax: validates .jsonc, e.g. config/fastfetch/config.jsonc).
+if ! command -v biome >/dev/null 2>&1; then
+  as_root curl -sSfL -o /usr/local/bin/biome \
+    "https://github.com/biomejs/biome/releases/download/@biomejs/biome@${BIOME_VERSION}/biome-linux-x64"
+  as_root chmod +x /usr/local/bin/biome
 fi


### PR DESCRIPTION
## What

Adds **biome** (pinned `2.5.0`, overridable via `BIOME_VERSION`) to `bin/install_check_tools.sh`.

## Why

`bin/install_check_tools.sh` is meant to be the single source of truth for the CI/web lint toolchain. It already installed zsh, shellcheck, yq, gitleaks and ratchet — but **not** biome. The CI job (`static_checks`) still installs biome inline, and `bin/lint_config.sh` requires biome to validate `.jsonc` files (`config/fastfetch/config.jsonc`); without it that step fails (`rc=1`).

This closes the last gap so the shared script fully covers the CI toolchain.

## Follow-up (manual, not in this PR)

Once merged, the inline "Install check tools" step in `.github/workflows/ci.yml`'s `static_checks` job can be replaced with:

```yaml
      - name: Install check tools
        run: ./bin/install_check_tools.sh
```

I can't push to `.github/workflows/` from this environment, so that one-line swap is left to you. After it, CI and the web SessionStart hook install the exact same toolchain from one place.

## Validation (run in this sandbox)

1. ✅ `shellcheck bin/install_check_tools.sh` clean.
2. ✅ Ran the installer → `biome --version` reports `2.5.0` at `/usr/local/bin/biome`.
3. ✅ `bin/lint_config.sh` PASS (validated `config/fastfetch/config.jsonc` via biome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRKXK1No1q6wfN3AmVFXDb)_