### PR TITLE
ci(pr): mark PR template Type section as a TaskRadio group

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,13 +15,13 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 
 ## Type
 
-<!-- Check all that apply. Must match the commit type. -->
-- [ ] feat — new functionality
-- [ ] fix — bug fix
-- [ ] chore — tooling / maintenance
-- [ ] docs — documentation only
-- [ ] refactor — no behavior change
-- [ ] ci — CI / workflow
+<!-- Pick exactly one (radio group); it must match the commit type. -->
+- [ ] feat — new functionality <!-- TaskRadio type -->
+- [ ] fix — bug fix <!-- TaskRadio type -->
+- [ ] chore — tooling / maintenance <!-- TaskRadio type -->
+- [ ] docs — documentation only <!-- TaskRadio type -->
+- [ ] refactor — no behavior change <!-- TaskRadio type -->
+- [ ] ci — CI / workflow <!-- TaskRadio type -->
 
 ## Verification
 

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,31 @@
+---
+name: pr-checklist
+# Block merging until every checklist item in the PR description is ticked.
+# Runs on `edited` too, so ticking a box in the PR body re-evaluates the check.
+# The result attaches to the PR head SHA; make this job a *required* status
+# check in the branch protection / ruleset for `main` to actually gate merges
+# (that part is a repo admin setting, it cannot live in this file).
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-checklist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-checklist:
+    runs-on: ubuntu-latest
+    steps:
+      # requireChecklist: also fail if the body has no checklist at all, so a
+      # PR that drops the template can't slip through. Mutually-exclusive
+      # choices (e.g. the Type section) use `<!-- TaskRadio name -->` so only
+      # one box per group is required; strike through N/A items to skip them.
+      - name: Require PR checklist complete
+        uses: mheap/require-checklist-action@9c8100a52aa9726d4648e61aa92415f6c843c990 # v2.6.1
+        with:
+          requireChecklist: true


### PR DESCRIPTION
## Summary

Prep for a PR-checklist merge gate: two changes on this branch.

1. Mark the PR template's mutually-exclusive Type section as a `<!-- TaskRadio type -->` group so the gate requires exactly one type instead of all six.
2. Add `.github/workflows/pr-checklist.yml` — uses `mheap/require-checklist-action@9c8100a52aa9726d4648e61aa92415f6c843c990` (v2.6.1, pinned) to block merging until every checklist item in the PR description is ticked.

The workflow file could not be pushed from the web session (no `workflow` scope); it was pushed from the CLI in a follow-up commit, tracked in #32.

## Changes

- Mark each `Type` option in `.github/PULL_REQUEST_TEMPLATE.md` with `<!-- TaskRadio type -->` and reword the hint to "Pick exactly one".
- Add `.github/workflows/pr-checklist.yml` (fires on `opened`/`edited`/`synchronize`/`reopened`).

## Type

<!-- Pick exactly one (radio group); it must match the commit type. -->
- [ ] feat — new functionality <!-- TaskRadio type -->
- [ ] fix — bug fix <!-- TaskRadio type -->
- [ ] chore — tooling / maintenance <!-- TaskRadio type -->
- [ ] docs — documentation only <!-- TaskRadio type -->
- [ ] refactor — no behavior change <!-- TaskRadio type -->
- [x] ci — CI / workflow <!-- TaskRadio type -->

## Verification

- [x] `lefthook run pre-commit` passes locally (lint, config, secrets, action-pinning)
- [x] CI is green
- [ ] ~~Manually verified the affected dotfile(s) load~~ (template + workflow only, N/A)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

closes #32

---
🤖 Generated with [Claude Code](https://claude.ai/code)