### PR TITLE
ci(pr): drop redundant "CI is green" checklist item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,9 +25,8 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 
 ## Verification
 
-<!-- How was this checked? -->
+<!-- How was this checked? (CI passing is enforced by branch protection.) -->
 - [ ] `lefthook run pre-commit` passes locally (lint, config, secrets)
-- [ ] CI is green
 - [ ] Manually verified the affected dotfile(s) load
 
 ## Checklist


### PR DESCRIPTION
## Summary

Remove the manual "CI is green" checkbox from the PR template. Now that
`require-checklist` is itself a CI check and branch protection enforces CI
before merge, the checkbox was redundant and self-referential (you could not
truthfully tick it until CI — including this very check — was already green).

## Changes

- Drop the `- [ ] CI is green` item from the Verification section of
  `.github/PULL_REQUEST_TEMPLATE.md` (note added that CI is enforced by
  branch protection).

## Type

<!-- Pick exactly one (radio group); it must match the commit type. -->
- [ ] feat — new functionality <!-- TaskRadio type -->
- [ ] fix — bug fix <!-- TaskRadio type -->
- [ ] chore — tooling / maintenance <!-- TaskRadio type -->
- [ ] docs — documentation only <!-- TaskRadio type -->
- [ ] refactor — no behavior change <!-- TaskRadio type -->
- [x] ci — CI / workflow <!-- TaskRadio type -->

## Verification

- [x] `lefthook run pre-commit` passes locally (lint, config, secrets)
- [ ] ~~Manually verified the affected dotfile(s) load~~ (template-only, N/A)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6WRJKgMKJmx58w9BtEgb)_