### PR TITLE
chore(pr): remove Type section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,16 +13,6 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 <!-- Bullet list of the concrete changes. -->
 -
 
-## Type
-
-<!-- Check all that apply. Must match the commit type. -->
-- [ ] feat — new functionality
-- [ ] fix — bug fix
-- [ ] chore — tooling / maintenance
-- [ ] docs — documentation only
-- [ ] refactor — no behavior change
-- [ ] ci — CI / workflow
-
 ## Verification
 
 <!-- How was this checked? -->


### PR DESCRIPTION
## Summary

TypeセクションはConventional Commitsのcommit typeと重複しており、lefthookが強制するため不要。またcheckboxが常に未チェック状態になるのも気持ち悪いため削除。

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` からTypeセクション（6行のcheckboxリスト）を削除

## Verification

- [x] `lefthook run pre-commit` passes locally (lint, config, secrets)
- [ ] CI is green
- [ ] ~~Manually verified the affected dotfile(s) load~~ (template-only, N/A)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

---
🤖 Generated with [Claude Code](https://claude.ai/code)