### PR TITLE
ci(pr): remove redundant Type section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,16 +13,6 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 <!-- Bullet list of the concrete changes. -->
 -
 
-## Type
-
-<!-- Pick exactly one (radio group); it must match the commit type. -->
-- [ ] feat — new functionality <!-- TaskRadio type -->
-- [ ] fix — bug fix <!-- TaskRadio type -->
-- [ ] chore — tooling / maintenance <!-- TaskRadio type -->
-- [ ] docs — documentation only <!-- TaskRadio type -->
-- [ ] refactor — no behavior change <!-- TaskRadio type -->
-- [ ] ci — CI / workflow <!-- TaskRadio type -->
-
 ## Verification
 
 <!-- How was this checked? (CI passing is enforced by branch protection.) -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 ### Branch & PR workflow
 - Never commit or push directly to `main`. Always branch: `git switch -c <type>/<short-desc>` (type ∈ feat|fix|chore|docs|refactor|ci).
 - lefthook blocks direct commits/pushes to `main` (`protect-main` in pre-commit & pre-push); GitHub branch protection enforces it server-side too.
-- Every change lands via a PR using `.github/PULL_REQUEST_TEMPLATE.md` — fill in Summary, Changes, Type (matching the commit type), Verification, and the checklist.
+- Every change lands via a PR using `.github/PULL_REQUEST_TEMPLATE.md` — fill in Summary, Changes, Verification, and the checklist. The change type lives in the commit subject (Conventional Commits), not a template field.
 - Keep PRs small: prefer 1 commit per PR; commit subject must satisfy the Conventional Commits check.
 
 ### PR updates


### PR DESCRIPTION
## Summary

Remove the `Type` section from the PR template (and its mention in
`AGENTS.md`). The change type is already encoded in the commit subject
(`type(scope): ...`) and enforced by the Conventional Commits commit-msg hook
and CI, so the template's Type checklist only duplicated that and needed
manual syncing. Dropping it also removes the only mutually-exclusive group,
simplifying the `require-checklist` gate.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: delete the `## Type` section (the six
  `feat/fix/chore/docs/refactor/ci` TaskRadio checkboxes).
- `AGENTS.md`: drop "Type (matching the commit type)" from the PR-workflow
  note; clarify the type lives in the commit subject.

## Verification

- [x] `lefthook run pre-commit` passes locally (lint, config, secrets)
- [ ] ~~Manually verified the affected dotfile(s) load~~ (docs/template only, N/A)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6WRJKgMKJmx58w9BtEgb)_