### PR TITLE
docs(pr-template): simplify Verification and clarify Summary rule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,6 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 <!-- Bullet list of the concrete changes. -->
 -
 
-## Verification
-
-<!-- How was this checked? (CI passing is enforced by branch protection.) -->
-- [ ] `lefthook run pre-commit` passes locally (lint, config, secrets)
-
 ## Checklist
 
 - [ ] Branched off `main` — no direct commits to `main`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 
 ## Summary
 
-<!-- このPRの意図（何を・なぜ）を簡潔な言葉で。1-3文。 -->
+<!-- State this PR's intent (what & why) concisely. 1-3 sentences. -->
 
 ## Changes
 
@@ -15,7 +15,7 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 
 ## Verification
 
-<!-- このPR固有の確認があれば書く（手順・結果など）。なければ "none"。CI は branch protection で担保。 -->
+<!-- PR-specific checks, if any (steps/results). Otherwise "none". CI is enforced by branch protection. -->
 -
 
 ## Checklist

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,11 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 <!-- Bullet list of the concrete changes. -->
 -
 
+## Verification
+
+<!-- このPR固有の確認があれば書く（手順・結果など）。なければ "none"。CI は branch protection で担保。 -->
+-
+
 ## Checklist
 
 - [ ] Branched off `main` — no direct commits to `main`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,6 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 
 <!-- How was this checked? (CI passing is enforced by branch protection.) -->
 - [ ] `lefthook run pre-commit` passes locally (lint, config, secrets)
-- [ ] Manually verified the affected dotfile(s) load
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Commit subjects must follow Conventional Commits (enforced by lefthook):
 
 ## Summary
 
-<!-- What does this PR change and why? 1-3 sentences. -->
+<!-- このPRの意図（何を・なぜ）を簡潔な言葉で。1-3文。 -->
 
 ## Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,9 @@
 - Claude Code auto-appends `🤖 Generated with Claude Code` to PR bodies and `Co-Authored-By: Claude ...` to commits — do not remove these.
 - Prefer 1 commit per PR. Write commit messages in English.
 
+### Language
+- Public artifacts (commit messages, PR title/body, code comments, docs) are written in English — English is the de facto standard for published work.
+- Chat/sessions with Claude are in Japanese.
+
 ### Commit signing
 - If `git commit -S` hangs: `export GPG_TTY=$(tty)` and ensure pinentry-mac is configured.


### PR DESCRIPTION
## Summary

Slim down the PR template's Verification section and document the language policy.

## Changes

- Drop fixed Verification items; make it a free-form field (auto-checks are covered by lefthook/CI)
- Summary guide now asks for a concise intent
- Add a Language policy to AGENTS.md: public artifacts in English, sessions in Japanese

## Verification

- none (docs-only)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none