### PR TITLE
feat(ghostty): add background blur for better readability with transparency

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -32,4 +32,5 @@ shell-integration-features = no-cursor,ssh-env,ssh-terminfo
 cursor-opacity = 0.5
 cursor-style-blink = true
 background-opacity = 0.6
+background-blur-radius = 50
 custom-shader = ./shaders/cursor_sweep.glsl


### PR DESCRIPTION
## Summary

Add `background-blur-radius = 50` to Ghostty config to improve terminal text readability while keeping the transparent background effect.

## Changes

- Add `background-blur-radius = 50` to `config/ghostty/config`

## Verification

- Reloaded Ghostty config with `cmd+shift+,` and visually confirmed blur was applied
- Confirmed terminal text is clearly readable with blur radius 50 on transparent background (`background-opacity = 0.6`)
- Compared blur radius 20 vs 50 — settled on 50 for better readability

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
