### PR TITLE
fix(ci): use editorconfig-checker binary name instead of ec alias

### DIFF
--- a/bin/install_check_tools.sh
+++ b/bin/install_check_tools.sh
@@ -56,10 +56,10 @@ if ! command -v biome >/dev/null 2>&1; then
 fi
 
 # editorconfig-checker (editorconfig: max line length, trailing ws, final newline).
-if ! command -v ec >/dev/null 2>&1; then
+if ! command -v editorconfig-checker >/dev/null 2>&1; then
   curl -sSfL "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v${EC_VERSION}/ec-linux-amd64.tar.gz" \
     | as_root tar -xz -C /usr/local/bin --strip-components=1 bin/ec-linux-amd64
-  as_root mv /usr/local/bin/ec-linux-amd64 /usr/local/bin/ec
+  as_root mv /usr/local/bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker
 fi
 
 # check-jsonschema (schema-validate: validates files declaring a "$schema").

--- a/bin/lint_editorconfig.sh
+++ b/bin/lint_editorconfig.sh
@@ -13,11 +13,11 @@ set -euo pipefail
 BASE_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." || exit 1; pwd)
 cd "$BASE_DIR" || exit 1
 
-if ! command -v ec >/dev/null 2>&1; then
-    echo "x editorconfig-checker (ec) not found; install it (brew install editorconfig-checker)" >&2
+if ! command -v editorconfig-checker >/dev/null 2>&1; then
+    echo "x editorconfig-checker not found; install it (brew install editorconfig-checker)" >&2
     exit 1
 fi
 
-# With explicit files, ec still reads .editorconfig + .editorconfig-checker.json
+# With explicit files, editorconfig-checker still reads .editorconfig + .editorconfig-checker.json
 # from the repo root, so per-file rules and disabled checks are respected.
-ec "$@"
+editorconfig-checker "$@"


### PR DESCRIPTION
## Summary

Rename the `ec` binary alias to `editorconfig-checker` throughout the toolchain so the name matches what `brew install editorconfig-checker` provides on macOS.

## Changes

- `bin/lint_editorconfig.sh`: check for and invoke `editorconfig-checker` instead of `ec`
- `bin/install_check_tools.sh`: install the Linux binary as `editorconfig-checker` instead of `ec`

## Verification

- Ran `git commit` locally and confirmed lefthook's `editorconfig` step passed with the renamed binary
- CI was initially failing because `install_check_tools.sh` still installed as `ec` — fixed in the amended commit

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
