### PR TITLE
chore(ghostty): remove background blur and allow revert commit type

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -32,5 +32,4 @@ shell-integration-features = no-cursor,ssh-env,ssh-terminfo
 cursor-opacity = 0.5
 cursor-style-blink = true
 background-opacity = 0.6
-background-blur-radius = 50
 custom-shader = ./shaders/cursor_sweep.glsl

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -85,11 +85,11 @@ commit-msg:
         case "$msg" in
           Merge*|Revert*|"fixup! "*|"squash! "*) exit 0 ;;
         esac
-        if echo "$msg" | grep -qE '^(feat|fix|chore|docs|refactor|ci)(\([a-z0-9-]+\))?!?: .+'; then
+        if echo "$msg" | grep -qE '^(feat|fix|chore|docs|refactor|ci|revert)(\([a-z0-9-]+\))?!?: .+'; then
           exit 0
         fi
         echo "x Not a valid Conventional Commits message:"
         echo "    $msg"
         echo "  example: feat(ghostty): add opacity toggle keybind"
-        echo "  type: feat|fix|chore|docs|refactor|ci"
+        echo "  type: feat|fix|chore|docs|refactor|ci|revert"
         exit 1


### PR DESCRIPTION
## Summary

- Remove `background-blur-radius = 50` from Ghostty config — text was unreadable with blur enabled
- Allow `revert` as a valid Conventional Commits type in lefthook

## Changes

- `config/ghostty/config`: remove `background-blur-radius = 50`
- `lefthook.yml`: add `revert` to the allowed commit type regex and error message

## Verification

- Restart Ghostty and confirm text is readable without blur
- Verify `revert(scope): message` commit messages now pass the conventional hook

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)