### PR TITLE
chore(bin): add tile-focused-workspace script for AeroSpace window layout

### DIFF
--- a/bin/tile-focused-workspace.sh
+++ b/bin/tile-focused-workspace.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+layout="$1"
+
+aerospace list-windows --workspace focused --format '%{window-id}' | xargs -n1 aerospace layout "$layout" --window-id


### PR DESCRIPTION
## Summary

- Add `bin/tile-focused-workspace.sh` — a helper script that applies a tiling or floating layout to all windows in the focused AeroSpace workspace
- Referenced by `.aerospace.toml` keybindings (`Alt+Shift+T` / `Alt+Shift+F`)

## Changes

- `bin/tile-focused-workspace.sh` (new): lists windows in the focused workspace and applies the given layout via `aerospace layout`

## Verification

- Confirmed the script is referenced in `.aerospace.toml` at lines 160–161
- Lefthook pre-commit hooks passed (editorconfig, shell-lint, gitleaks, secret-files)

## Checklist

- [x] Conventional Commits format
- [x] No sensitive information included
- [x] CI checks passed locally via lefthook

🤖 Generated with [Claude Code](https://claude.com/claude-code)