### PR TITLE
chore: introduce bats unit-test harness with first guard tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         run: ./bin/install_check_tools.sh
       - name: Lint shell scripts
         run: ./bin/lint_shell.sh
+      - name: Run unit tests (bats)
+        run: ./bin/run_tests.sh
       - name: Lint zsh syntax
         run: ./bin/lint_zsh.sh
       - name: Validate config files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ### Hooks & CI
 - Lefthook runs various checks on commit; CI mirrors the same checks.
-- Commit messages must follow Conventional Commits: `type(scope): description` — type ∈ {feat, fix, chore, docs, refactor, ci}.
+- Commit messages must follow Conventional Commits: `type(scope): description` — type ∈ {feat, fix, chore, docs, refactor, ci, test}. Use `test` for changes that only touch the test suite (e.g. `test/*.bats`).
 - For CI failures: `gh run view <run_id> --log-failed`.
 
 ### ~/.config policy
@@ -14,7 +14,7 @@
 - To skip parts of `.zshrc` in CI, use a dedicated env flag — not an early return.
 
 ### Branch & PR workflow
-- Never commit or push directly to `main`. Always branch: `git switch -c <type>/<short-desc>` (type ∈ feat|fix|chore|docs|refactor|ci).
+- Never commit or push directly to `main`. Always branch: `git switch -c <type>/<short-desc>` (type ∈ feat|fix|chore|docs|refactor|ci|test).
 - lefthook blocks direct commits/pushes to `main` (`protect-main` in pre-commit & pre-push); GitHub branch protection enforces it server-side too.
 - Every change lands via a PR using `.github/PULL_REQUEST_TEMPLATE.md` — fill in Summary, Changes, Verification, and the checklist. The change type lives in the commit subject (Conventional Commits), not a template field.
 - The Verification section must list the actual steps taken in the session (e.g. reloaded config, visually confirmed X), not just restate the generic checklist items.

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -5,6 +5,8 @@ tap "b-ramsey/kali"
 tap "morantron/tmux-fingers"
 # Clone of cat(1) with syntax highlighting and Git integration
 brew "bat"
+# Bash Automated Testing System (bin/run_tests.sh)
+brew "bats-core"
 # Searches a binary image for embedded files and executable code
 brew "binwalk"
 # Toolchain of the web; parses/validates JSON with comments (JSONC)

--- a/bin/check_brewfile_sort.sh
+++ b/bin/check_brewfile_sort.sh
@@ -3,14 +3,20 @@
 # Verify each Brewfile keeps its tap/brew/cask entries sorted A-Z (case-insensitive),
 # matching the "Keep entries sorted A-Z" convention.
 # Single source of truth shared by CI and the lefthook pre-commit hook.
+# Pass files as arguments; with none, the repo's four Brewfiles are checked.
 
 set -euo pipefail
 
 BASE_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." || exit 1; pwd)
 cd "$BASE_DIR" || exit 1
 
+files=("$@")
+if [ "${#files[@]}" -eq 0 ]; then
+    files=(Brewfile.basic Brewfile.common Brewfile.linux Brewfile.macos)
+fi
+
 rc=0
-for bf in Brewfile.basic Brewfile.common Brewfile.linux Brewfile.macos; do
+for bf in "${files[@]}"; do
     [ -f "$bf" ] || continue
     for kind in tap brew cask; do
         names=$(grep -E "^$kind \"" "$bf" | sed -E "s/^$kind \"([^\"]+)\".*/\1/" || true)

--- a/bin/install_check_tools.sh
+++ b/bin/install_check_tools.sh
@@ -22,11 +22,11 @@ as_root() {
   fi
 }
 
-# zsh (zsh-syntax check) + shellcheck (shell-lint) via apt.
+# zsh (zsh-syntax check) + shellcheck (shell-lint) + bats (unit tests) via apt.
 if command -v apt-get >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
   as_root apt-get update -qq || true
-  as_root apt-get install -y -qq zsh shellcheck >/dev/null
+  as_root apt-get install -y -qq zsh shellcheck bats >/dev/null
 fi
 
 # mikefarah yq (config-syntax: `yq -p toml|json|yaml`).

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Run the bats unit-test suite (test/*.bats).
+# Single source of truth shared by CI and the lefthook pre-commit hook, so the
+# tests never diverge between local checks and CI.
+
+set -euo pipefail
+
+BASE_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." || exit 1; pwd)
+cd "$BASE_DIR" || exit 1
+
+if ! command -v bats >/dev/null 2>&1; then
+    echo "x bats not found; install it (brew install bats-core, or apt-get install bats)" >&2
+    exit 1
+fi
+
+bats --print-output-on-failure test/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -90,11 +90,11 @@ commit-msg:
         case "$msg" in
           Merge*|Revert*|"fixup! "*|"squash! "*) exit 0 ;;
         esac
-        if echo "$msg" | grep -qE '^(feat|fix|chore|docs|refactor|ci|revert)(\([a-z0-9-]+\))?!?: .+'; then
+        if echo "$msg" | grep -qE '^(feat|fix|chore|docs|refactor|ci|test|revert)(\([a-z0-9-]+\))?!?: .+'; then
           exit 0
         fi
         echo "x Not a valid Conventional Commits message:"
         echo "    $msg"
         echo "  example: feat(ghostty): add opacity toggle keybind"
-        echo "  type: feat|fix|chore|docs|refactor|ci|revert"
+        echo "  type: feat|fix|chore|docs|refactor|ci|test|revert"
         exit 1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,11 @@ pre-commit:
     shell-lint:
       glob: "bin/*.sh"
       run: ./bin/lint_shell.sh
+    unit-tests:
+      glob:
+        - "bin/*.sh"
+        - "test/*.bats"
+      run: ./bin/run_tests.sh
     zsh-syntax:
       glob:
         - ".zshrc"

--- a/test/check_brewfile_sort.bats
+++ b/test/check_brewfile_sort.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+# Tests for bin/check_brewfile_sort.sh.
+#
+# The script must accept Brewfiles whose tap/brew/cask entries are sorted A-Z
+# (case-insensitive) and reject any section that is out of order. With no
+# arguments it checks the repo's own Brewfiles; with arguments it checks the
+# given files (used here to feed fixtures).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/check_brewfile_sort.sh"
+  TMP="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "the repo's own Brewfiles are sorted" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts a correctly sorted Brewfile" {
+  printf 'brew "alpha"\nbrew "bravo"\nbrew "charlie"\n' >"$TMP/Brewfile.sorted"
+  run "$SCRIPT" "$TMP/Brewfile.sorted"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects an out-of-order Brewfile" {
+  printf 'brew "charlie"\nbrew "alpha"\n' >"$TMP/Brewfile.bad"
+  run "$SCRIPT" "$TMP/Brewfile.bad"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not sorted"* ]]
+}
+
+@test "sort is case-insensitive" {
+  printf 'brew "Alpha"\nbrew "bravo"\nbrew "Charlie"\n' >"$TMP/Brewfile.case"
+  run "$SCRIPT" "$TMP/Brewfile.case"
+  [ "$status" -eq 0 ]
+}
+
+@test "checks tap/brew/cask sections independently" {
+  printf 'tap "z/last"\ntap "a/first"\nbrew "alpha"\n' >"$TMP/Brewfile.sections"
+  run "$SCRIPT" "$TMP/Brewfile.sections"
+  [ "$status" -eq 1 ]
+}

--- a/test/check_secret_files.bats
+++ b/test/check_secret_files.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+# Tests for bin/check_secret_files.sh.
+#
+# The script must REJECT sensitive filenames (private keys, key/cert
+# extensions, .env files) and ACCEPT ordinary files and the documented
+# .env.{example,sample,template,dist} exceptions. Names are passed as
+# arguments, so these are pure name checks: no real files need to exist.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/check_secret_files.sh"
+}
+
+@test "accepts ordinary files" {
+  run "$SCRIPT" README.md config/starship.toml .zshrc
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects an SSH private key by basename" {
+  run "$SCRIPT" id_rsa
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Sensitive files detected"* ]]
+}
+
+@test "rejects id_ed25519 in a subdirectory" {
+  run "$SCRIPT" some/nested/path/id_ed25519
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects sensitive extensions" {
+  for f in cert.pem private.key bundle.p12 vault.kdbx server.pfx store.jks; do
+    run "$SCRIPT" "$f"
+    [ "$status" -eq 1 ]
+  done
+}
+
+@test "rejects a bare .env file" {
+  run "$SCRIPT" .env
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects an environment-specific .env.local file" {
+  run "$SCRIPT" .env.local
+  [ "$status" -eq 1 ]
+}
+
+@test "allows example/sample/template/dist env files" {
+  run "$SCRIPT" .env.example .env.sample config/.env.template .env.dist
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects the whole set if even one file is sensitive" {
+  run "$SCRIPT" README.md id_rsa notes.txt
+  [ "$status" -eq 1 ]
+}

--- a/test/dotfiles_sync_check.bats
+++ b/test/dotfiles_sync_check.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+# Behavioural tests for bin/dotfiles_sync_check.sh, the shell-startup reminder
+# that nags when the dotfiles repo is out of sync between machines.
+#
+# The script always inspects its OWN repo (dirname "$0"/..), so each test runs
+# a *copy* of the script placed inside a throwaway git repo. That repo is wired
+# to a local bare "remote" to exercise the ahead/behind branches without any
+# network. XDG_CACHE_HOME is redirected into the temp dir and a fresh fetch
+# stamp is pre-written so the script's once-per-24h background `git fetch`
+# never fires (no network, no flakiness). Warnings go to stderr, which bats
+# folds into $output.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SRC="$REPO_ROOT/bin/dotfiles_sync_check.sh"
+  TMP="$(mktemp -d)"
+  export XDG_CACHE_HOME="$TMP/cache"
+
+  REPO="$TMP/repo"
+  mkdir -p "$REPO/bin"
+  cp "$SRC" "$REPO/bin/dotfiles_sync_check.sh"
+  SCRIPT="$REPO/bin/dotfiles_sync_check.sh"
+
+  git -c init.defaultBranch=main init -q "$REPO"
+  git -C "$REPO" config user.email test@example.com
+  git -C "$REPO" config user.name "Test"
+  echo seed >"$REPO/seed.txt"
+  git -C "$REPO" add -A          # includes the copied bin/ script, so a fresh repo is clean
+  git -C "$REPO" commit -qm "feat: seed"
+
+  # Pre-stamp the fetch cache as "just fetched" so the script skips its
+  # background git fetch entirely.
+  mkdir -p "$XDG_CACHE_HOME/dotfiles"
+  date +%s >"$XDG_CACHE_HOME/dotfiles/last_fetch"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# Give $REPO a bare upstream and push main so @{upstream} is tracked.
+add_upstream() {
+  git init -q --bare "$TMP/remote.git"
+  git -C "$REPO" remote add origin "$TMP/remote.git"
+  git -C "$REPO" push -q -u origin main
+}
+
+@test "DOTFILES_NO_SYNC_CHECK short-circuits with no output" {
+  echo dirty >>"$REPO/seed.txt"          # would otherwise warn
+  DOTFILES_NO_SYNC_CHECK=1 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "clean repo with no upstream is silent" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "warns about uncommitted changes" {
+  echo dirty >>"$REPO/seed.txt"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"uncommitted changes"* ]]
+}
+
+@test "warns about untracked files too" {
+  echo new >"$REPO/untracked.txt"
+  run "$SCRIPT"
+  [[ "$output" == *"uncommitted changes"* ]]
+}
+
+@test "warns about unpushed commits when ahead of upstream" {
+  add_upstream
+  echo more >>"$REPO/seed.txt"
+  git -C "$REPO" commit -qam "feat: ahead"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unpushed commit"* ]]
+  [[ "$output" != *"behind upstream"* ]]
+}
+
+@test "warns when behind upstream" {
+  add_upstream
+  # Advance the remote from a second clone, then refresh our remote-tracking
+  # ref (the script itself won't fetch — stamp is fresh), leaving HEAD behind.
+  git clone -q -b main "$TMP/remote.git" "$TMP/other"
+  git -C "$TMP/other" config user.email other@example.com
+  git -C "$TMP/other" config user.name "Other"
+  echo upstream >>"$TMP/other/seed.txt"
+  git -C "$TMP/other" commit -qam "feat: upstream change"
+  git -C "$TMP/other" push -q origin main
+  git -C "$REPO" fetch -q origin
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"behind upstream"* ]]
+  [[ "$output" != *"unpushed commit"* ]]
+}

--- a/test/mklink_rmworld_sync.bats
+++ b/test/mklink_rmworld_sync.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+# Guards the invariant both scripts document in their own comments:
+# bin/rmworld.sh must unlink exactly the set of $HOME entries that
+# bin/mklink.sh links. If someone adds/removes a link in one script but
+# forgets the other, mkworld/rmworld stop being inverses and stale symlinks
+# get left behind (or real files get clobbered). This test fails loudly the
+# moment the two lists drift apart.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  MKLINK="$REPO_ROOT/bin/mklink.sh"
+  RMWORLD="$REPO_ROOT/bin/rmworld.sh"
+}
+
+# The $HOME entry names mklink.sh creates. Each `ln` line is either
+#   ln ... "$BASE_DIR/<src>" ./<name>   -> link name is <name>
+#   ln ... "$BASE_DIR/<src>" ./         -> link name is basename(<src>)
+# (e.g. `... "$BASE_DIR/config" ./.config` links .config, not config), so the
+# destination wins when it is named and the source basename is used otherwise.
+mklink_targets() {
+  awk '/ln -/ {
+    s = $0
+    sub(/^[^"]*"/, "", s); src = s; sub(/".*/, "", src)   # src = $BASE_DIR/...
+    dest = $NF
+    if (dest == "./") { sub(/\/$/, "", src); sub(/.*\//, "", src); print src }
+    else { sub(/^\.\//, "", dest); sub(/\/$/, "", dest); print dest }
+  }' "$MKLINK" | sort -u
+}
+
+# Entries rmworld.sh unlinks: the argument of each unlink_if_symlink call,
+# leading "./" stripped, trailing slash normalised.
+rmworld_targets() {
+  grep -oE 'unlink_if_symlink "\./[^"]*"' "$RMWORLD" \
+    | sed -E 's/.*"\.\/([^"]*)"/\1/' \
+    | sed -E 's#/$##' \
+    | sort -u
+}
+
+@test "every file mklink.sh links is unlinked by rmworld.sh" {
+  diff <(mklink_targets) <(rmworld_targets)
+}
+
+@test "mklink.sh actually links something (guards against a broken parser)" {
+  run mklink_targets
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}


### PR DESCRIPTION
## Summary

Stand up a bats-based unit-test harness for the `bin/` guard scripts and grow
it with high-value behavioural tests, so a broken guard can no longer pass CI
silently (previously the scripts were only ever run against the repo's own
clean files). Also allow the `test` Conventional Commit type for test-only
changes.

## Changes

- **Test harness**: `bin/run_tests.sh` (runner shared by CI and lefthook),
  wired into CI (`ci.yml`), a lefthook `unit-tests` pre-commit hook,
  `install_check_tools.sh` (apt) and `Brewfile.common` (bats-core).
- **Guard tests**: `test/check_secret_files.bats` (sensitive-filename guard:
  positive / negative / exception cases) and `test/check_brewfile_sort.bats`
  (sorted / unsorted / case-insensitive / per-section). `check_brewfile_sort.sh`
  now accepts optional file arguments so fixtures can be fed in (no-arg
  behaviour unchanged).
- **Behavioural tests**: `test/dotfiles_sync_check.bats` exercises
  `dotfiles_sync_check.sh` (skip flag, clean repo, uncommitted, untracked,
  ahead, behind) by running a copy of the script in a throwaway git repo wired
  to a local bare remote — no network touched.
- **Symmetry guard**: `test/mklink_rmworld_sync.bats` asserts `rmworld.sh`
  unlinks exactly the `$HOME` entries `mklink.sh` links (an invariant both
  scripts document but nothing enforced).
- **`test` commit type**: added to the `commit-msg` validator in `lefthook.yml`
  and to the documented type set in `AGENTS.md`/`CLAUDE.md`.

## Verification

- `./bin/run_tests.sh` → 21/21 pass (13 guard + 8 new behavioural/symmetry).
- `./bin/lint_shell.sh` → clean.
- lefthook pre-commit + commit-msg hooks passed on every commit (including the
  `test:`-typed commit against the updated `conventional` check).
- CI (`ci`) green on the head commit.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)