### PR TITLE
feat(tmux): show session name in status-left instead of hostname

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -78,9 +78,9 @@ set -g @extrakto_filter_order "line word quote"
 set -g status-style "bg=#073642,fg=#839496"
 set -g message-style "bg=#073642,fg=#2aa198"
 set -g message-command-style "bg=#073642,fg=#2aa198"
-set -g status-left-length 30
+set -g status-left-length 50
 set -g status-right-length 100
-set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #h #[fg=#268bd2,bg=#073642,nobold] "
+set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #{session_name} #[fg=#268bd2,bg=#073642,nobold] "
 set -g status-right "#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
 setw -g window-status-format "#[fg=#{?window_bell_flag,#dc322f,#586e75},bg=#073642] #I:#W "
 setw -g window-status-current-format "#[fg=#073642,bg=#2aa198]#[fg=#002b36,bg=#2aa198,bold] #I:#W #[fg=#2aa198,bg=#073642]"


### PR DESCRIPTION
## Summary

tmux のステータスバー左側を、ホスト名 (`#h`) からセッション名 (`#{session_name}`) に切り替える。複数セッションを行き来する際にどのセッションにいるかを一目で判別できるようにするのが目的。

## Changes

- `.tmux.conf`: `status-left` の `#h` → `#{session_name}` に変更
- `.tmux.conf`: `status-left-length` を 30 → 50 に拡張（長めのセッション名が切れないように）

## Verification

- `tmux source-file ~/.tmux.conf` でリロードし、ステータス左にセッション名が表示されることを確認
- gitleaks: `origin/main..HEAD` で no leaks found
- lefthook pre-commit / pre-push / commit-msg すべて pass

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
