### PR TITLE
feat(git): add difftastic for on-demand structural diffs

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -4,6 +4,9 @@
   co = checkout
   l = log --graph --color=always --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'
   lp = log -p
+  # Structural (syntax-aware) diff via difftastic; default `git diff` stays delta.
+  dft = difftool
+  dftlog = -c diff.external=difft log -p --ext-diff
 
 [core]
   excludesfile = ~/.gitignore
@@ -18,6 +21,7 @@
 [diff]
   algorithm = histogram
   colorMoved = default
+  tool = difftastic
 
 [diff "exif"]
   textconv = exiftool
@@ -63,6 +67,16 @@
   hunk-header-style = omit
   syntax-theme = Solarized (dark)
   hyperlinks = true
+
+[difftool]
+  prompt = false
+
+[difftool "difftastic"]
+  cmd = difft "$LOCAL" "$REMOTE"
+
+# Let `git dft` page structural diffs through the pager, like normal diffs.
+[pager]
+  difftool = true
 
 [rerere]
   enabled = true

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -19,6 +19,8 @@ brew "cowsay"
 brew "ctags"
 # Power of curl, ease of use of httpie
 brew "curlie"
+# Structural diff that understands syntax (on-demand via `git dft`)
+brew "difftastic"
 # More intuitive version of du in rust
 brew "dust"
 # Enforce .editorconfig rules (line length, trailing whitespace, final newline)


### PR DESCRIPTION
## Summary

Adds [difftastic](https://github.com/Wilfred/difftastic), a syntax-aware (AST-based) diff tool, and wires it as a git *difftool* so it's available on demand via `git dft` — while the default `git diff` / `git log` keep using delta. This complements delta (line-based + syntax highlighting) rather than replacing it.

## Changes

- `Brewfile.common`: add `brew "difftastic"` (sorted between `curlie` and `dust`).
- `.gitconfig`:
  - `dft = difftool` and `dftlog = -c diff.external=difft log -p --ext-diff` aliases.
  - `[diff] tool = difftastic` + `[difftool "difftastic"] cmd = difft "$LOCAL" "$REMOTE"`.
  - `[pager] difftool = true` so structural diffs page like normal diffs.
- Deliberately **not** set on `diff.external`, so the default diff/log path stays fast and line-based (delta).

## Verification

- `./bin/check_brewfile_sort.sh` → pass (A–Z order kept).
- `./bin/lint_editorconfig.sh` → pass.
- `git config -f .gitconfig --list` parses cleanly (valid syntax).

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiFqxhd6f5g9gWexU5j2QV)_