### PR TITLE
test: cover lint_config, lint_zsh, and extract+test lefthook guards

### DIFF
--- a/bin/check_commit_msg.sh
+++ b/bin/check_commit_msg.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Validate a commit message against Conventional Commits
+# (type(scope)!: description), type in {feat,fix,chore,docs,refactor,ci,test,
+# revert}. Single source of truth shared by CI checks and the lefthook
+# commit-msg hook, so the rule lives in ONE place instead of inline YAML.
+#
+# Usage: check_commit_msg.sh <path-to-commit-msg-file>
+# Only the first line (the subject) is checked. Merge/Revert/fixup!/squash!
+# subjects that git generates are exempt.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $(basename "$0") <commit-msg-file>" >&2
+    exit 2
+fi
+
+msg=$(head -1 "$1")
+
+case "$msg" in
+    Merge*|Revert*|"fixup! "*|"squash! "*) exit 0 ;;
+esac
+
+if echo "$msg" | grep -qE '^(feat|fix|chore|docs|refactor|ci|test|revert)(\([a-z0-9-]+\))?!?: .+'; then
+    exit 0
+fi
+
+echo "x Not a valid Conventional Commits message:"
+echo "    $msg"
+echo "  example: feat(ghostty): add opacity toggle keybind"
+echo "  type: feat|fix|chore|docs|refactor|ci|test|revert"
+exit 1

--- a/bin/protect_main.sh
+++ b/bin/protect_main.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Refuse to put commits on, or push to, the 'main' branch. Work happens on
+# feature branches + PRs; GitHub branch protection is the server-side
+# enforcement, this is the fast local feedback. Single source of truth shared
+# by the lefthook pre-commit and pre-push hooks, so the rule lives in ONE place
+# instead of inline YAML.
+#
+# Usage:
+#   protect_main.sh commit          # pre-commit: blocks if HEAD is 'main'
+#   protect_main.sh push            # pre-push: reads git's pre-push stdin
+#                                   #   (lines: <local-ref> <local-sha> <remote-ref> <remote-sha>)
+#                                   #   and blocks any push to refs/heads/main
+# Intentional bypass: git commit/push --no-verify
+
+set -euo pipefail
+
+mode="${1:-}"
+
+case "$mode" in
+    commit)
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+            echo "x Direct commits to 'main' are blocked."
+            echo "  Create a feature branch and open a PR:"
+            echo "    git switch -c <type>/<short-desc>"
+            echo "  Intentional bypass: git commit --no-verify"
+            exit 1
+        fi
+        ;;
+    push)
+        while read -r _ _ remote_ref _; do
+            case "$remote_ref" in
+                refs/heads/main)
+                    echo "x Direct push to 'main' is blocked. Open a PR instead."
+                    echo "  Intentional bypass: git push --no-verify"
+                    exit 1
+                    ;;
+            esac
+        done
+        ;;
+    *)
+        echo "usage: $(basename "$0") {commit|push}" >&2
+        exit 2
+        ;;
+esac

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,15 +8,7 @@ pre-commit:
     # GitHub branch protection is the server-side enforcement; this is the
     # fast local feedback. Bypass intentionally with: git commit --no-verify
     protect-main:
-      run: |
-        branch=$(git rev-parse --abbrev-ref HEAD)
-        if [ "$branch" = "main" ]; then
-          echo "x Direct commits to 'main' are blocked."
-          echo "  Create a feature branch and open a PR:"
-          echo "    git switch -c <type>/<short-desc>"
-          echo "  Intentional bypass: git commit --no-verify"
-          exit 1
-        fi
+      run: ./bin/protect_main.sh commit
     shell-lint:
       glob: "bin/*.sh"
       run: ./bin/lint_shell.sh
@@ -81,32 +73,11 @@ pre-push:
     # pre-push stdin (each line: <local-ref> <local-sha> <remote-ref> <remote-sha>)
     # to the command, so we can inspect exactly what is being pushed.
     protect-main:
-      run: |
-        while read -r _ _ remote_ref _; do
-          case "$remote_ref" in
-            refs/heads/main)
-              echo "x Direct push to 'main' is blocked. Open a PR instead."
-              echo "  Intentional bypass: git push --no-verify"
-              exit 1
-              ;;
-          esac
-        done
+      run: ./bin/protect_main.sh push
     gitleaks-full:
       run: gitleaks git --no-banner --redact
 
 commit-msg:
   commands:
     conventional:
-      run: |
-        msg=$(head -1 "{1}")
-        case "$msg" in
-          Merge*|Revert*|"fixup! "*|"squash! "*) exit 0 ;;
-        esac
-        if echo "$msg" | grep -qE '^(feat|fix|chore|docs|refactor|ci|test|revert)(\([a-z0-9-]+\))?!?: .+'; then
-          exit 0
-        fi
-        echo "x Not a valid Conventional Commits message:"
-        echo "    $msg"
-        echo "  example: feat(ghostty): add opacity toggle keybind"
-        echo "  type: feat|fix|chore|docs|refactor|ci|test|revert"
-        exit 1
+      run: ./bin/check_commit_msg.sh {1}

--- a/test/check_commit_msg.bats
+++ b/test/check_commit_msg.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+# Tests for bin/check_commit_msg.sh, the Conventional Commits validator the
+# lefthook commit-msg hook calls. The message is read from a file (git passes
+# the commit-msg path), so each case writes a one-line fixture and feeds its
+# path. Only the subject line is validated.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/check_commit_msg.sh"
+  TMP="$(mktemp -d)"
+  MSG="$TMP/msg"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# Write $1 as the commit subject and run the script against it.
+check() {
+  printf '%s\n' "$1" >"$MSG"
+  run "$SCRIPT" "$MSG"
+}
+
+@test "accepts a plain type: description" {
+  check "feat: add opacity toggle"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts a type(scope): description" {
+  check "fix(ghostty): correct keybind"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts a breaking-change marker type(scope)!: description" {
+  check "refactor(zsh)!: drop legacy loader"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts every allowed type" {
+  for t in feat fix chore docs refactor ci test revert; do
+    check "$t: something"
+    [ "$status" -eq 0 ] || { echo "type '$t' was rejected"; return 1; }
+  done
+}
+
+@test "rejects an unknown type" {
+  check "wip: half-done thing"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Not a valid Conventional Commits message"* ]]
+}
+
+@test "rejects a missing colon/description" {
+  check "feat add a thing"
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects an empty description after the colon" {
+  check "feat: "
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects an uppercase scope" {
+  check "feat(Ghostty): add thing"
+  [ "$status" -eq 1 ]
+}
+
+@test "exempts a Merge subject" {
+  check "Merge branch 'main' into feature"
+  [ "$status" -eq 0 ]
+}
+
+@test "exempts a Revert subject" {
+  check 'Revert "feat: add a thing"'
+  [ "$status" -eq 0 ]
+}
+
+@test "exempts a fixup! subject" {
+  check "fixup! feat: add a thing"
+  [ "$status" -eq 0 ]
+}
+
+@test "only the first line is checked (a bad body is ignored)" {
+  printf 'feat: good subject\n\nthis body line is not conventional\n' >"$MSG"
+  run "$SCRIPT" "$MSG"
+  [ "$status" -eq 0 ]
+}
+
+@test "errors out when given no argument" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+}

--- a/test/lint_config.bats
+++ b/test/lint_config.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+# Tests for bin/lint_config.sh, which validates the *syntax* (not schema) of
+# structured config files. The script routes by extension:
+#   .json/.toml/.yaml/.yml -> yq -p <parser>
+#   .jsonc                  -> biome lint (yq has no JSONC mode)
+# Fixtures are passed as explicit arguments, so the git-ls-files default path is
+# not exercised here (the no-args case proves the repo's own files are valid).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/lint_config.sh"
+  TMP="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "accepts valid JSON" {
+  printf '{ "a": 1, "b": ["x", "y"] }\n' >"$TMP/good.json"
+  run "$SCRIPT" "$TMP/good.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects malformed JSON" {
+  printf '{ "a": 1, \n' >"$TMP/bad.json"   # unterminated object
+  run "$SCRIPT" "$TMP/bad.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid json syntax: $TMP/bad.json"* ]]
+}
+
+@test "accepts valid TOML" {
+  printf 'a = 1\nb = "x"\n' >"$TMP/good.toml"
+  run "$SCRIPT" "$TMP/good.toml"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects malformed TOML" {
+  printf 'a = = 1\n' >"$TMP/bad.toml"
+  run "$SCRIPT" "$TMP/bad.toml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid toml syntax: $TMP/bad.toml"* ]]
+}
+
+@test "accepts valid YAML (both .yaml and .yml route to the yaml parser)" {
+  printf 'a: 1\nb:\n  - x\n  - y\n' >"$TMP/good.yaml"
+  printf 'a: 1\n' >"$TMP/good.yml"
+  run "$SCRIPT" "$TMP/good.yaml" "$TMP/good.yml"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects malformed YAML" {
+  printf 'a: 1\n  b: 2\n' >"$TMP/bad.yaml"   # bad indentation / mapping
+  run "$SCRIPT" "$TMP/bad.yaml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid yaml syntax: $TMP/bad.yaml"* ]]
+}
+
+@test "accepts valid JSONC (comments + trailing commas) via biome" {
+  cat >"$TMP/good.jsonc" <<'EOF'
+{
+  // a line comment
+  "a": 1,
+  /* block comment */
+  "b": [1, 2,],
+}
+EOF
+  run "$SCRIPT" "$TMP/good.jsonc"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects malformed JSONC via biome" {
+  printf '{ "a": 1 \n' >"$TMP/bad.jsonc"   # unterminated object
+  run "$SCRIPT" "$TMP/bad.jsonc"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid jsonc syntax"* ]]
+}
+
+@test "fails a mixed batch if any single file is invalid" {
+  printf '{ "a": 1 }\n' >"$TMP/ok.json"
+  printf 'a = = 1\n' >"$TMP/bad.toml"
+  run "$SCRIPT" "$TMP/ok.json" "$TMP/bad.toml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid toml syntax: $TMP/bad.toml"* ]]
+}
+
+@test "no arguments and a clean repo exits 0 (repo's own config files are valid)" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+}

--- a/test/lint_zsh.bats
+++ b/test/lint_zsh.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# Tests for bin/lint_zsh.sh, which syntax-checks zsh files (zsh -n).
+# Fixtures are passed as explicit arguments, so no git state is involved and
+# the script never falls back to scanning the repo. Mirrors lint_bash.bats /
+# lint_lua.bats so the three syntax linters stay symmetric.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/lint_zsh.sh"
+  TMP="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "accepts a syntactically valid zsh file" {
+  printf 'alias ll="ls -la"\nfor f in a b c; do print -- "$f"; done\n' >"$TMP/good.zsh"
+  run "$SCRIPT" "$TMP/good.zsh"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects a zsh file with a syntax error" {
+  printf 'if [[ -n "$x" ]]; then\n  print hi\n' >"$TMP/bad.zsh"   # missing fi
+  run "$SCRIPT" "$TMP/bad.zsh"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails the batch if any one file is broken" {
+  printf 'print ok\n' >"$TMP/ok.zsh"
+  printf 'case $x in\n' >"$TMP/nope.zsh"   # missing patterns/esac
+  run "$SCRIPT" "$TMP/ok.zsh" "$TMP/nope.zsh"
+  [ "$status" -ne 0 ]
+}
+
+@test "no arguments and a clean repo exits 0 (repo's own zsh is valid)" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+}

--- a/test/protect_main.bats
+++ b/test/protect_main.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# Tests for bin/protect_main.sh, the guard the lefthook pre-commit and pre-push
+# hooks call to keep work off the 'main' branch.
+#
+#   commit mode -> inspects `git rev-parse --abbrev-ref HEAD` of the CWD, so
+#                  each case cd's into a throwaway git repo on a chosen branch.
+#   push mode   -> parses git's pre-push stdin (<local-ref> <local-sha>
+#                  <remote-ref> <remote-sha> per line); pure text, no git state.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/protect_main.sh"
+  TMP="$(mktemp -d)"
+
+  REPO="$TMP/repo"
+  git init -q -b main "$REPO"
+  git -C "$REPO" config user.email t@t.test
+  git -C "$REPO" config user.name test
+  git -C "$REPO" commit -q --allow-empty -m "feat: init"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# --- commit mode -----------------------------------------------------------
+
+@test "commit: blocks a commit while HEAD is main" {
+  cd "$REPO"
+  run "$SCRIPT" commit
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Direct commits to 'main' are blocked"* ]]
+}
+
+@test "commit: allows a commit on a feature branch" {
+  git -C "$REPO" switch -q -c feat/thing
+  cd "$REPO"
+  run "$SCRIPT" commit
+  [ "$status" -eq 0 ]
+}
+
+# --- push mode -------------------------------------------------------------
+
+@test "push: blocks a push whose remote ref is refs/heads/main" {
+  run bash -c \
+    'printf "%s\n" "refs/heads/main abc refs/heads/main def" | "$1" push' _ "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Direct push to 'main' is blocked"* ]]
+}
+
+@test "push: allows a push to a non-main remote ref" {
+  run bash -c \
+    'printf "%s\n" "refs/heads/feat abc refs/heads/feat def" | "$1" push' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "push: blocks if any one of several pushed refs targets main" {
+  feed='refs/heads/feat abc refs/heads/feat def
+refs/heads/x abc refs/heads/main def'
+  run bash -c 'printf "%s\n" "$2" | "$1" push' _ "$SCRIPT" "$feed"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Direct push to 'main' is blocked"* ]]
+}
+
+@test "push: empty stdin (nothing to push) exits 0" {
+  run bash -c 'printf "" | "$1" push' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# --- usage -----------------------------------------------------------------
+
+@test "errors out on an unknown mode" {
+  run "$SCRIPT" bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "errors out with no mode" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Close the highest-value gaps in the bats test suite (45 → 80 tests) and pull the inline bash out of `lefthook.yml` so its logic becomes testable. No behavior changes for users — checks run exactly as before.

## Changes

- `test/lint_config.bats` — covers the extension routing in `lint_config.sh` (`yq` for json/toml/yaml, `biome` for jsonc) plus the mixed-batch failure path. Previously untested.
- `test/lint_zsh.bats` — mirrors `lint_bash`/`lint_lua` so the three syntax linters stay symmetric (closes a parity gap).
- Extract the inline bash from `lefthook.yml` into `bin/` scripts, matching the repo's "logic lives only in scripts (single source of truth)" rule:
  - `bin/check_commit_msg.sh` — Conventional Commits subject validator
  - `bin/protect_main.sh` — commit/push guards keeping work off `main`
  - `lefthook.yml` now just calls these.
- `test/check_commit_msg.bats` — type list, scope, `!` breaking marker, and Merge/Revert/fixup exemptions.
- `test/protect_main.bats` — both `commit` and `push` guard modes, multi-ref pushes, empty stdin.

## Verification

- `./bin/lint_shell.sh` — pass (shellcheck + `bash -n` on the two new scripts)
- `./bin/run_tests.sh` — 80/80 pass
- `./bin/lint_editorconfig.sh`, `./bin/lint_config.sh` — pass
- lefthook ran on commit: the newly-extracted `protect-main` and `conventional` hooks executed via the new scripts and passed end-to-end (self-validating)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none