### PR TITLE
docs(brewfile): document the basic vs common split rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,12 @@ truth, so the two never diverge.
 - `config/` — XDG configs symlinked to `~/.config` (nvim, ghostty, starship, …).
 - Root dotfiles — `.zshrc`, `.tmux.conf`, `.vimrc`, `.gitconfig`, … into `$HOME`.
 - `Brewfile.{basic,common,macos,linux}` — Homebrew bundles, sorted A–Z per
-  section (`check_brewfile_sort.sh`).
+  section (`check_brewfile_sort.sh`). Split rule: `basic` = anything the shell
+  needs at load time (prompt, completion, plugin manager, eval-cache inlines,
+  startup aliases/`LS_COLORS`) — litmus test: if removing it breaks
+  `ci_zsh_loading_test.sh`/`ci_tmux_loading_test.sh`, it's `basic`; CI installs
+  only `basic`. `common` = full-workstation tooling not required to start the
+  shell. `macos`/`linux` = platform-specific additions.
 - `.github/workflows/ci.yml`, `lefthook.yml` — CI and its local mirror.
 - `.claude/` (settings + web SessionStart hook), `.codex/skills/` (Codex skills).
 

--- a/Brewfile.basic
+++ b/Brewfile.basic
@@ -1,3 +1,9 @@
+# Brewfile.basic — the minimal bootstrap layer the shell itself depends on.
+# A package belongs here if .zshrc / .tmux.conf reference it at load time
+# (prompt, completion, plugin manager, eval-cache inlines, startup aliases /
+# LS_COLORS). Litmus test: if removing it would break bin/ci_zsh_loading_test.sh
+# or bin/ci_tmux_loading_test.sh, it goes here. CI installs ONLY this file
+# (Brewfile.common is skipped when CI=true). Everything else -> Brewfile.common.
 # NOTE: Keep entries sorted A-Z within this file.
 # Additional Homebrew tap
 tap "rs/tap"

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -1,3 +1,7 @@
+# Brewfile.common — full-workstation tooling that the shell does NOT need to
+# start (editors, git / k8s / security utilities, etc.). Installed on real
+# machines; skipped in CI, which installs only Brewfile.basic. Anything the
+# shell depends on at load time belongs in Brewfile.basic — see its header.
 # NOTE: Keep entries sorted A-Z within this file.
 # Additional Homebrew tap
 tap "b-ramsey/kali"


### PR DESCRIPTION
## Summary

Documents the de-facto rule for which `Brewfile` a package belongs in, so future entries land in the right place. Prompted by the carapace move (#49) — the basic/common boundary turned out to be precise and worth writing down.

## Changes

- `Brewfile.basic` header: define `basic` = the minimal bootstrap layer the shell depends on at load time (prompt, completion, plugin manager, eval-cache inlines, startup aliases / `LS_COLORS`), with the litmus test "if removing it breaks `ci_zsh_loading_test.sh` / `ci_tmux_loading_test.sh`, it goes here" and the note that CI installs only this file.
- `Brewfile.common` header: define `common` = full-workstation tooling not required to start the shell; points back to basic for the rule.
- `AGENTS.md` repository map: add the same split rule (one source of truth for the convention; `CLAUDE.md` symlink intact).

## Rule (for reference)

- **basic** — anything `.zshrc` / `.tmux.conf` need at load time. Litmus: removing it breaks the CI loading tests. CI installs only `basic` (`setup_homebrew.sh` skips `common` when `CI=true`).
- **common** — everyday/interactive tooling for a full workstation that the shell does not need to start.
- **macos / linux** — platform-specific additions.

## Verification

- `./bin/lint_editorconfig.sh` → pass (Markdown exempt from line length; Brewfile lines ≤ 80).
- `./bin/check_brewfile_sort.sh` → pass (headers only; no entry changes).

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Context: #49 (carapace moved to `Brewfile.basic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiFqxhd6f5g9gWexU5j2QV)_