### PR TITLE
feat(cli): add btop, procs, doggo, gping and alias standard commands

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -94,6 +94,10 @@ alias reload="exec zsh"
 alias cat='bat'
 alias less='bat --pager=less'
 alias curl='curlie' # for pretty-print
+alias top='btop'
+alias ps='procs'
+alias ping='gping'
+alias dig='doggo'
 alias grep='grep --color=auto'
 alias navi='navi --print --prevent-interpolation'
 alias mysqlsh='mysqlsh --quiet-start=2 --no-name-cache'

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -15,6 +15,8 @@ brew "bats-core"
 brew "binwalk"
 # Toolchain of the web; parses/validates JSON with comments (JSONC)
 brew "biome"
+# Resource monitor with a nice TUI (top/htop replacement)
+brew "btop"
 # Validate JSON/TOML/YAML against the JSON Schema they declare ($schema)
 brew "check-jsonschema"
 # Apjanke's fork of the classic cowsay project
@@ -25,6 +27,8 @@ brew "ctags"
 brew "curlie"
 # Structural diff that understands syntax (on-demand via `git dft`)
 brew "difftastic"
+# Command-line DNS client (dig replacement) with colored output
+brew "doggo"
 # More intuitive version of du in rust
 brew "dust"
 # Enforce .editorconfig rules (line length, trailing whitespace, final newline)
@@ -59,6 +63,8 @@ brew "glow"
 brew "gnu-sed"
 # GNU Privacy Guard (OpenPGP)
 brew "gnupg"
+# Ping, but with a graph (ping replacement)
+brew "gping"
 # Enhanced version of john, a UNIX password cracker
 brew "john-jumbo"
 # Lightweight and flexible command-line JSON processor
@@ -95,6 +101,8 @@ brew "netcat"
 brew "nmap"
 # SSL/TLS VPN implementing OSI layer 2 or 3 secure network extension
 brew "openvpn"
+# Modern replacement for ps written in Rust
+brew "procs"
 # Generic machine emulator and virtualizer
 brew "qemu"
 # Pin/lint GitHub Actions workflows to immutable commit SHAs


### PR DESCRIPTION
## Summary

Add four modern, trending CLI tools as replacements for classic commands, and alias the originals so they take effect transparently in interactive shells.

## Changes

- `Brewfile.common` (A–Z sorted, real-machine tier): add `btop`, `procs`, `doggo`, `gping`
- `.zshrc`: alias the standard commands they replace
  - `top` → `btop` (resource monitor TUI)
  - `ps` → `procs` (process viewer)
  - `ping` → `gping` (ping with a graph)
  - `dig` → `doggo` (DNS client)
- Placed in `Brewfile.common` rather than `Brewfile.basic`: none are needed at shell-init time or in CI, so they belong in the real-machine-only tier. Aliases are only *defined* (not executed) at load, so loading `.zshrc` without these installed (e.g. CI) is safe.

## Verification

- `./bin/check_brewfile_sort.sh` — pass
- `./bin/lint_shell.sh` — pass
- `zsh -n .zshrc` — syntax OK
- lefthook pre-commit/commit-msg hooks (brewfile-sort, zsh-syntax, editorconfig, gitleaks, conventional) — all pass

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUcGN9sWFB6E31DhSn6qJR)_