### PR TITLE
feat(brew): startup drift reminder + weekly background auto-upgrade (macOS)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -376,3 +376,16 @@ if [[ -z "${DOTFILES_NO_SYNC_CHECK:-}" ]]; then
   [[ -x "$_dotfiles_dir/bin/dotfiles_sync_check.sh" ]] && "$_dotfiles_dir/bin/dotfiles_sync_check.sh"
   unset _dotfiles_dir
 fi
+
+#=====================
+# Brewfile drift reminder
+#=====================
+# Remind at startup when a Brewfile bundle has packages that aren't installed
+# yet (after adding a formula, or on a freshly bootstrapped machine). Notify
+# only and throttled to once per 24h; see bin/brew_bundle_check.sh. Skipped in
+# CI via DOTFILES_NO_BREW_CHECK.
+if [[ -z "${DOTFILES_NO_BREW_CHECK:-}" ]]; then
+  _dotfiles_dir="${${(%):-%x}:A:h}"
+  [[ -x "$_dotfiles_dir/bin/brew_bundle_check.sh" ]] && "$_dotfiles_dir/bin/brew_bundle_check.sh"
+  unset _dotfiles_dir
+fi

--- a/bin/brew_bundle_check.sh
+++ b/bin/brew_bundle_check.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Brewfile drift reminder.
+#
+# Warns at shell startup when a Brewfile bundle lists packages that aren't
+# installed yet — e.g. after adding a formula, or on a freshly bootstrapped
+# machine — so the tools you expect are actually present. Notify-only: it never
+# installs anything, it just prints the exact `brew bundle install` to run.
+#
+# `brew bundle check` is comparatively slow, so it runs at most once per 24h and
+# its result is cached; every other login just reads the cached result and is
+# effectively free. Same "cheap nag, throttled expensive part" trade-off as
+# dotfiles_sync_check.sh, so the "missing" warning can be one day stale.
+#
+# Skipped entirely when DOTFILES_NO_BREW_CHECK is set (used by CI so the load
+# test neither slows down nor prints reminder noise).
+
+set -u
+
+[ -n "${DOTFILES_NO_BREW_CHECK:-}" ] && exit 0
+
+# brew not installed yet -> stay silent; bootstrap (bin/mkworld.sh) handles that.
+command -v brew >/dev/null 2>&1 || exit 0
+
+REPO_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." 2>/dev/null && pwd) || exit 0
+
+# Brewfiles to check: shell-load essentials + full workstation + this platform.
+files=(Brewfile.basic Brewfile.common)
+case "$(uname)" in
+    Darwin) files+=(Brewfile.macos) ;;
+    Linux) files+=(Brewfile.linux) ;;
+esac
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles"
+mkdir -p "$cache_dir" 2>/dev/null || true
+stamp="$cache_dir/last_brew_check"
+result="$cache_dir/brew_missing"
+
+# Re-run the (slow) check at most once per 24h; otherwise reuse the cached list.
+need_check=1
+if [ -f "$stamp" ] && [ -f "$result" ]; then
+    last=$(cat "$stamp" 2>/dev/null || echo 0)
+    case "$last" in
+        '' | *[!0-9]*) last=0 ;;
+    esac
+    if [ "$(( $(date +%s) - last ))" -lt 86400 ]; then
+        need_check=0
+    fi
+fi
+
+if [ "$need_check" -eq 1 ]; then
+    missing=()
+    for f in "${files[@]}"; do
+        [ -f "$REPO_DIR/$f" ] || continue
+        brew bundle check --file="$REPO_DIR/$f" >/dev/null 2>&1 || missing+=("$f")
+    done
+    # Persist the unsatisfied Brewfiles (one per line) + a stamp so later logins
+    # are free. Written even when empty, so "all satisfied" is also cached.
+    if [ "${#missing[@]}" -gt 0 ]; then
+        printf '%s\n' "${missing[@]}" >"$result" 2>/dev/null || true
+    else
+        : >"$result" 2>/dev/null || true
+    fi
+    date +%s >"$stamp" 2>/dev/null || true
+fi
+
+# Nothing unsatisfied (empty or absent cache) -> stay silent.
+[ -s "$result" ] || exit 0
+
+yellow=$'\033[33m'
+cyan=$'\033[36m'
+reset=$'\033[0m'
+
+# One line per unsatisfied Brewfile, with a ready-to-run install command.
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    printf '%s[brew]%s %s has uninstalled packages -> %sbrew bundle install --file=%s/%s%s\n' \
+        "$yellow" "$reset" "$f" "$cyan" "$REPO_DIR" "$f" "$reset" >&2
+done <"$result"
+
+exit 0

--- a/bin/ci_zsh_loading_test.sh
+++ b/bin/ci_zsh_loading_test.sh
@@ -7,6 +7,9 @@ export COLORTERM="truecolor"
 # Don't run the dotfiles sync reminder during the load test: it would touch the
 # network (background fetch) and print reminder noise unrelated to this check.
 export DOTFILES_NO_SYNC_CHECK=1
+# Likewise skip the Brewfile drift reminder: CI installs only Brewfile.basic, so
+# a check would always report common/* missing, and `brew bundle check` is slow.
+export DOTFILES_NO_BREW_CHECK=1
 
 die() {
   echo "CI error: $*" >&2

--- a/bin/mkworld.sh
+++ b/bin/mkworld.sh
@@ -40,3 +40,9 @@ fi
 if command -v lefthook >/dev/null 2>&1; then
     (cd "$BASE_DIR" && lefthook install && git config --local commit.template .gitmessage)
 fi
+
+# macOS: enable weekly background brew auto-upgrade (formulae; casks stay manual).
+# Non-fatal so a hiccup here never aborts the bootstrap.
+if [ "$(uname)" = "Darwin" ] && [ "${SKIP_BREW:-0}" = "0" ]; then
+    sh "$BASE_DIR/bin/setup_brew_autoupdate.sh" || true
+fi

--- a/bin/setup_brew_autoupdate.sh
+++ b/bin/setup_brew_autoupdate.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Enable weekly, unattended background Homebrew upgrades on macOS.
+#
+# Uses the homebrew/autoupdate tap, which installs a launchd agent that runs
+# `brew update` + `brew upgrade` + `brew cleanup` on a fixed interval, in the
+# background, and surfaces a native macOS notification when it runs — no shell
+# nag at login. Idempotent: re-running while it's already scheduled is a no-op.
+#
+# Deliberately NOT passing --sudo: a cask that needs an admin password can't be
+# answered by an unattended job, so without --sudo such a cask is simply skipped
+# (logged), never hangs. Upgrade your casks by hand (`brew upgrade --cask`) when
+# you're at the keyboard. Formulae live under the user-owned brew prefix and
+# never need sudo.
+#
+# launchd is macOS-only, so this is a no-op elsewhere.
+
+set -eu
+
+# Weekly. brew autoupdate takes the interval in seconds.
+INTERVAL="${BREW_AUTOUPDATE_INTERVAL:-604800}"
+
+if [ "$(uname)" != "Darwin" ]; then
+    echo "brew autoupdate relies on launchd; skipping on non-macOS." >&2
+    exit 0
+fi
+
+BREW_BIN="$(command -v brew 2>/dev/null || true)"
+if [ -z "$BREW_BIN" ]; then
+    for cand in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+        if [ -x "$cand" ]; then
+            BREW_BIN="$cand"
+            break
+        fi
+    done
+fi
+if [ -z "$BREW_BIN" ]; then
+    echo "brew not found; skipping autoupdate setup." >&2
+    exit 0
+fi
+
+# Make sure the tap providing the `autoupdate` subcommand is present.
+"$BREW_BIN" tap homebrew/autoupdate >/dev/null 2>&1 || true
+
+# Already scheduled? Leave it untouched so this stays idempotent.
+if "$BREW_BIN" autoupdate status 2>/dev/null | grep -Eqi 'and running|are enabled'; then
+    echo "brew autoupdate already running; nothing to do."
+    exit 0
+fi
+
+# Start it: update + upgrade (formulae, plus non-greedy casks) + cleanup, weekly,
+# with a macOS notification. No --sudo on purpose (see header).
+"$BREW_BIN" autoupdate start "$INTERVAL" --upgrade --cleanup --enable-notification
+echo "brew autoupdate started: every $INTERVAL s, background upgrade + cleanup."

--- a/test/brew_bundle_check.bats
+++ b/test/brew_bundle_check.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+# Behavioural tests for bin/brew_bundle_check.sh, the shell-startup reminder that
+# nags when a Brewfile bundle has uninstalled packages.
+#
+# The script shells out to `brew bundle check`, so each test runs a *copy* of it
+# inside a throwaway repo with Brewfiles present and a stub `brew` on PATH whose
+# exit code is scripted via BREW_CHECK_RC ("0" = satisfied, anything else =
+# missing). XDG_CACHE_HOME is redirected into the temp dir so the 24h throttle
+# stamp and the cached result file can be inspected and pre-seeded. Warnings go
+# to stderr, which bats folds into $output.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  TMP="$(mktemp -d)"
+  export XDG_CACHE_HOME="$TMP/cache"
+
+  REPO="$TMP/repo"
+  mkdir -p "$REPO/bin"
+  cp "$REPO_ROOT/bin/brew_bundle_check.sh" "$REPO/bin/brew_bundle_check.sh"
+  chmod +x "$REPO/bin/brew_bundle_check.sh"
+  SCRIPT="$REPO/bin/brew_bundle_check.sh"
+  # The script checks these by name; their contents are irrelevant to the stub.
+  for f in Brewfile.basic Brewfile.common Brewfile.macos Brewfile.linux; do
+    echo "brew \"placeholder\"" >"$REPO/$f"
+  done
+
+  # Stub brew: `brew bundle check ...` exits with BREW_CHECK_RC (default 0).
+  STUB="$TMP/stubbin"
+  mkdir -p "$STUB"
+  cat >"$STUB/brew" <<'STUBEOF'
+#!/bin/bash
+if [ "$1" = "bundle" ] && [ "$2" = "check" ]; then
+  exit "${BREW_CHECK_RC:-0}"
+fi
+exit 0
+STUBEOF
+  chmod +x "$STUB/brew"
+  PATH="$STUB:$PATH"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "DOTFILES_NO_BREW_CHECK short-circuits with no output" {
+  BREW_CHECK_RC=1 DOTFILES_NO_BREW_CHECK=1 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "stays silent when brew is not installed" {
+  # Run with a PATH that has neither the stub nor a real brew.
+  PATH="/nonexistent" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "silent when all bundles are satisfied" {
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  # The result cache exists but is empty.
+  [ -f "$XDG_CACHE_HOME/dotfiles/brew_missing" ]
+  [ ! -s "$XDG_CACHE_HOME/dotfiles/brew_missing" ]
+}
+
+@test "warns and names the unsatisfied bundle when packages are missing" {
+  BREW_CHECK_RC=1 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[brew]"* ]]
+  [[ "$output" == *"Brewfile.basic"* ]]
+  [[ "$output" == *"brew bundle install --file="* ]]
+}
+
+@test "caches the result and a stamp, then reuses it without re-checking" {
+  BREW_CHECK_RC=1 run "$SCRIPT"
+  [ -f "$XDG_CACHE_HOME/dotfiles/last_brew_check" ]
+  [ -s "$XDG_CACHE_HOME/dotfiles/brew_missing" ]
+
+  # Within 24h the stub flipping to "satisfied" must NOT change the cached nag.
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  [[ "$output" == *"Brewfile.basic"* ]]
+}
+
+@test "re-checks once the throttle stamp is older than 24h" {
+  BREW_CHECK_RC=1 run "$SCRIPT"          # seed a "missing" cache
+  [[ "$output" == *"Brewfile.basic"* ]]
+
+  # Backdate the stamp beyond 24h; a now-satisfied check must clear the nag.
+  echo "$(( $(date +%s) - 90000 ))" >"$XDG_CACHE_HOME/dotfiles/last_brew_check"
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  [ -z "$output" ]
+}

--- a/test/setup_brew_autoupdate.bats
+++ b/test/setup_brew_autoupdate.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+# Behavioural tests for bin/setup_brew_autoupdate.sh, which enables the
+# homebrew/autoupdate launchd agent on macOS. The script shells out to `brew`
+# and `uname`, so each test puts stubs on PATH: `uname` reports the OS via
+# STUB_UNAME, and `brew` records every invocation to BREW_LOG and answers
+# `autoupdate status` from STUB_RUNNING. No real Homebrew or launchd is touched.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  TMP="$(mktemp -d)"
+  SCRIPT="$REPO_ROOT/bin/setup_brew_autoupdate.sh"
+  BREW_LOG="$TMP/brew.log"
+  export BREW_LOG
+
+  STUB="$TMP/stubbin"
+  mkdir -p "$STUB"
+
+  cat >"$STUB/uname" <<'STUBEOF'
+#!/bin/bash
+echo "${STUB_UNAME:-Darwin}"
+STUBEOF
+
+  cat >"$STUB/brew" <<'STUBEOF'
+#!/bin/bash
+echo "brew $*" >>"$BREW_LOG"
+if [ "$1" = "autoupdate" ] && [ "$2" = "status" ]; then
+  if [ "${STUB_RUNNING:-0}" = "1" ]; then
+    echo "Autoupdate is installed and running."
+  else
+    echo "Autoupdate is not configured."
+  fi
+fi
+exit 0
+STUBEOF
+
+  chmod +x "$STUB/uname" "$STUB/brew"
+  PATH="$STUB:$PATH"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "no-op on non-macOS (no brew calls)" {
+  STUB_UNAME=Linux run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping on non-macOS"* ]]
+  [ ! -f "$BREW_LOG" ]
+}
+
+@test "on macOS with nothing scheduled, taps and starts with the right flags" {
+  STUB_UNAME=Darwin STUB_RUNNING=0 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run cat "$BREW_LOG"
+  [[ "$output" == *"brew tap homebrew/autoupdate"* ]]
+  [[ "$output" == *"brew autoupdate start 604800 --upgrade --cleanup --enable-notification"* ]]
+}
+
+@test "does not pass --sudo (casks needing a password stay manual)" {
+  STUB_UNAME=Darwin STUB_RUNNING=0 run "$SCRIPT"
+  run cat "$BREW_LOG"
+  [[ "$output" != *"--sudo"* ]]
+}
+
+@test "idempotent: already running means no start call" {
+  STUB_UNAME=Darwin STUB_RUNNING=1 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already running"* ]]
+  run cat "$BREW_LOG"
+  [[ "$output" != *"autoupdate start"* ]]
+}
+
+@test "honours a custom interval via BREW_AUTOUPDATE_INTERVAL" {
+  STUB_UNAME=Darwin STUB_RUNNING=0 BREW_AUTOUPDATE_INTERVAL=86400 run "$SCRIPT"
+  run cat "$BREW_LOG"
+  [[ "$output" == *"brew autoupdate start 86400 --upgrade"* ]]
+}


### PR DESCRIPTION
## Summary

Two Homebrew quality-of-life additions: a notify-only startup reminder when a Brewfile bundle has uninstalled packages, and an unattended weekly background auto-upgrade on macOS.

## Changes

- **Brewfile drift reminder** (`bin/brew_bundle_check.sh`): at login, warns when `Brewfile.basic` + `Brewfile.common` + the platform bundle list packages that aren't installed, printing the exact `brew bundle install --file=...` to run. **Notify-only — never installs.** Wraps Homebrew's native `brew bundle check`; the slow check runs at most once per 24h and the result is cached so other logins are effectively free. Silent when `brew` is absent or `DOTFILES_NO_BREW_CHECK` is set. Wired into `.zshrc`; CI skips it via `DOTFILES_NO_BREW_CHECK` in `bin/ci_zsh_loading_test.sh`.
- **Weekly background auto-upgrade** (`bin/setup_brew_autoupdate.sh`): enables the `homebrew/autoupdate` launchd agent — weekly `brew update` + `upgrade` + `cleanup` in the background, with a native macOS notification (no shell nag). Idempotent; no-op off macOS. **No `--sudo` on purpose**, so a cask needing a password is skipped (logged) rather than hanging an unattended job — casks stay a manual `brew upgrade --cask`. Wired into `bin/mkworld.sh` on macOS (non-fatal).
- **Tests**: `test/brew_bundle_check.bats` and `test/setup_brew_autoupdate.bats` stub `brew`/`uname` to cover notify / silent / caching / 24h-throttle, and non-macOS no-op / tap+start flags / absent `--sudo` / idempotency / custom interval.

## Verification

- `./bin/lint_shell.sh`, `./bin/lint_zsh.sh`, `./bin/lint_editorconfig.sh` — all pass
- `bats test/` — 91 tests pass
- lefthook pre-commit/commit-msg ran clean on each commit (gitleaks, conventional commits, full unit-tests)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none