### PR TITLE
docs: require red-green TDD when adding or changing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ truth, so the two never diverge.
 - GitHub Actions `uses:` must be pinned to a full commit SHA, not a tag.
 - Config files with a top-level `$schema` are validated against it
   (`lint_schema.sh`) — keep the key accurate.
+- TDD: when adding or changing a test, prove it fails first (red), then make it
+  pass (green) — never ship a test you've only seen pass. Break the thing under
+  test (or the assertion) so the test actually fails for the expected reason,
+  then revert and confirm green. Especially for the `ci_*_test.sh` e2e checks,
+  where a typo'd assertion can silently pass forever.
 
 ### Conventions
 


### PR DESCRIPTION
## Summary

Record red-green TDD as a working rule in the repo's shared agent notes: a test must be seen failing before it's made to pass. Captures a discipline that was being skipped (e.g. PR #53 only ever showed the e2e test passing, never failing).

## Changes

- Add one bullet to `AGENTS.md` (= `CLAUDE.md`) under **Hooks & CI**: when adding or changing a test, break the thing under test (or the assertion), confirm it fails for the expected reason (red), then revert and confirm green — never ship a test you've only seen pass. Called out specifically for the `ci_*_test.sh` e2e checks, where a typo'd assertion can pass forever unnoticed.

## Verification

- `./bin/lint_editorconfig.sh AGENTS.md` — passes.
- `CLAUDE.md` symlink to `AGENTS.md` verified intact.
- Practiced the rule itself on the existing e2e test before writing this down: broke `alias vi='nvim'` → `'vim'` in `.zshrc`, ran `./bin/ci_tmux_interactive_test.sh`, confirmed it fails at the alias assertion (exit 1, pane dump shows `vi is an alias for vim`), then reverted and confirmed green.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EWQed135fxg7HXMJYaAQ8)_