### PR TITLE
chore(brew): remove multipass from macOS Brewfile

### DIFF
--- a/Brewfile.macos
+++ b/Brewfile.macos
@@ -17,8 +17,6 @@ cask "google-japanese-ime"
 cask "hammerspoon"
 # Tool to control external monitor brightness & volume
 cask "monitorcontrol"
-# Orchestrates virtual Ubuntu instances
-cask "multipass"
 # Control your tools with a few keystrokes
 cask "raycast"
 # Move and resize windows using keyboard shortcuts or snap areas


### PR DESCRIPTION
## Summary

multipass（仮想 Ubuntu 環境）を macOS Brewfile から削除する。

## Changes

- `Brewfile.macos` から `cask "multipass"` とそのコメントを削除

## Verification

- CI（lefthook pre-commit / pre-push）が通過済み：gitleaks clean、brewfile-sort パス

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)