### PR TITLE
feat(vim): bootstrap + guard the legacy .vimrc and add e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,17 @@ jobs:
 
       - name: Interactive e2e for the g repo-jump command (ghq -> fzf -> cd)
         run: ./bin/ci_g_command_test.sh
+
+  vim_guard_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Ensure vim + tmux are present
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vim tmux
+
+      - name: Legacy .vimrc guard (no-plugin startup must be clean)
+        run: ./bin/ci_vim_guard_test.sh

--- a/.github/workflows/vim-monthly.yml
+++ b/.github/workflows/vim-monthly.yml
@@ -1,0 +1,31 @@
+---
+# Monthly, no-cache end-to-end test of the legacy NeoBundle-based .vimrc.
+#
+# Runs bin/ci_vim_loading_test.sh, which installs every plugin from scratch and
+# asserts Vim then starts with zero errors. The full clone is deliberately
+# uncached so this doubles as a link-rot canary for the deprecated upstreams:
+# if one of the old GitHub repos disappears, the install — and this job — fails
+# loudly. It's slow and network-bound, hence monthly + manual, not per-push.
+name: vim-monthly
+on:
+  schedule:
+    - cron: '0 6 1 * *'   # 06:00 UTC on the 1st of each month
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  vim-legacy-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Ensure vim + tmux are present
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vim tmux
+
+      - name: Legacy vim e2e (install all plugins, assert clean startup)
+        run: ./bin/ci_vim_loading_test.sh

--- a/.vimrc
+++ b/.vimrc
@@ -61,11 +61,26 @@ nnoremap <silent> <C-x>3 :vsp<CR>
 " 次のバッファに切り替え
 nmap <C-T> :bn<CR>
 
-" Neobundle bootstrap
+" Neobundle bootstrap: auto-install the plugin manager on a fresh machine, then
+" let NeoBundleCheck (bottom of file) install the plugins. If neobundle is still
+" unavailable afterwards (offline, no git, or $VIM_NO_BOOTSTRAP set) the whole
+" plugin block below is skipped so Vim starts clean instead of erroring on every
+" NeoBundle command / blocking on a "Press ENTER" prompt.
+let s:neobundle_dir = expand('~/.vim/bundle/neobundle.vim')
+let s:has_neobundle = filereadable(s:neobundle_dir . '/autoload/neobundle.vim')
 if has('vim_starting')
 	set nocompatible               " Be iMproved
-	set runtimepath+=~/.vim/bundle/neobundle.vim/
+	if !s:has_neobundle && executable('git') && empty($VIM_NO_BOOTSTRAP)
+		call delete(s:neobundle_dir, 'd')
+		call system('git clone https://github.com/Shougo/neobundle.vim ' . shellescape(s:neobundle_dir))
+		let s:has_neobundle = filereadable(s:neobundle_dir . '/autoload/neobundle.vim')
+	endif
+	if s:has_neobundle
+		let &runtimepath .= ',' . s:neobundle_dir
+	endif
 endif
+
+if s:has_neobundle
 call neobundle#begin(expand('~/.vim/bundle/'))
 NeoBundleFetch 'Shougo/neobundle.vim'
 
@@ -255,10 +270,13 @@ augroup HighlightTrailingSpaces
 augroup END
 
 call neobundle#end()
+endif
 
 syntax enable
 set background=dark
 filetype plugin indent on " Required!
-colorscheme solarized
+silent! colorscheme solarized
 
-NeoBundleCheck
+if s:has_neobundle
+	NeoBundleCheck
+endif

--- a/bin/ci_vim_guard_test.sh
+++ b/bin/ci_vim_guard_test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Fast guard test for the legacy .vimrc: on a machine with NO plugins installed,
+# Vim must still start completely clean instead of erroring on every NeoBundle
+# command and blocking on a "Press ENTER" prompt.
+#
+# This exercises the degrade-gracefully path of .vimrc's bootstrap: with
+# $VIM_NO_BOOTSTRAP set, the auto-install of neobundle is skipped, so the whole
+# plugin block is guarded out. It installs nothing and touches no network, so
+# unlike ci_vim_loading_test.sh (the full monthly install) this is cheap enough
+# to run on every push.
+set -euo pipefail
+
+die() { echo "CI error: $*" >&2; exit 1; }
+
+command -v vim  >/dev/null 2>&1 || die "vim not installed"
+command -v tmux >/dev/null 2>&1 || die "tmux not installed"
+REPO="$PWD"
+VIMRC="$REPO/.vimrc"
+[ -f "$VIMRC" ] || die "no .vimrc in $REPO"
+echo "== $(vim --version | head -1) =="
+
+HOME_DIR="$(mktemp -d)"
+SOCK="ci_vim_guard_$$"
+cleanup() {
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  rm -rf "$HOME_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Isolated HOME with an empty bundle dir: no neobundle, no plugins.
+mkdir -p "$HOME_DIR/.vim/bundle" "$HOME_DIR/.vim/undo" "$HOME_DIR/tmp"
+cp "$VIMRC" "$HOME_DIR/.vimrc"
+
+# Assert 1 (headless): sourcing .vimrc with no plugins yields no error messages,
+# exits cleanly, and really is in the guarded path (the NeoBundle command, which
+# only the plugin manager defines, must be absent).
+echo "== headless: no-plugin startup must be clean =="
+msgs="$HOME_DIR/messages.txt"
+HOME="$HOME_DIR" VIM_NO_BOOTSTRAP=1 vim -N -u "$HOME_DIR/.vimrc" \
+  -c 'set nomore' \
+  -c "redir! > $msgs" \
+  -c 'silent messages' \
+  -c 'silent echo "NEOBUNDLE_CMD=".(exists(":NeoBundle")?"present":"absent")' \
+  -c 'redir END' -c 'qall!' </dev/null >/dev/null 2>&1 || die "vim exited non-zero with no plugins"
+
+echo "---- :messages ----"; cat "$msgs"; echo "-------------------"
+if grep -nE "E[0-9]{2,}:|Not an editor command|Unknown function|Cannot find color scheme|Error detected" "$msgs"; then
+  die "no-plugin startup produced Vim errors (the guard regressed)"
+fi
+grep -q "NEOBUNDLE_CMD=absent" "$msgs" ||
+  die "expected the guarded path (NeoBundle command should be undefined without plugins)"
+echo "== headless no-plugin startup clean =="
+
+# Assert 2 (real terminal): confirm there is no "Press ENTER" prompt or error
+# wall — the original symptom — and Vim lands on a normal editing screen.
+echo "== real-terminal: no Press-ENTER / error wall =="
+tmux -L "$SOCK" new-session -d -x 120 -y 40 \
+  "env HOME='$HOME_DIR' VIM_NO_BOOTSTRAP=1 TERM=xterm-256color vim -N -u '$HOME_DIR/.vimrc'" ||
+  die "failed to start tmux session"
+
+screen=""
+for _ in $(seq 1 50); do
+  screen="$(tmux -L "$SOCK" capture-pane -p 2>/dev/null || true)"
+  printf '%s\n' "$screen" | grep -qE '\[No Name\]|VIM - Vi IMproved' && break
+  sleep 0.1
+done
+if printf '%s\n' "$screen" | grep -qiE 'Press ENTER|Not an editor command|E[0-9]{2,}:|Unknown function'; then
+  echo "---- pane ----"; printf '%s\n' "$screen" >&2
+  die "Vim showed an error / Press-ENTER prompt on no-plugin startup (guard regressed)"
+fi
+printf '%s\n' "$screen" | grep -qE '\[No Name\]|VIM - Vi IMproved' ||
+  { echo "---- pane ----"; printf '%s\n' "$screen" >&2; die "Vim did not reach a normal startup screen"; }
+tmux -L "$SOCK" send-keys ':qa!' Enter
+echo "== real-terminal no-plugin startup clean =="
+
+echo "PASS"

--- a/bin/ci_vim_loading_test.sh
+++ b/bin/ci_vim_loading_test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# End-to-end test for the *legacy* Vim config (.vimrc) — the NeoBundle-based
+# setup, distinct from the Neovim config under config/nvim.
+#
+# Why this exists: .vimrc bootstraps ~20 plugins through NeoBundle (a deprecated
+# plugin manager) plus a compiled vimproc and the solarized colorscheme. On a
+# machine where those aren't installed, every `NeoBundle ...` line throws E492,
+# `neobundle#begin`/`#end` throw E117, `colorscheme solarized` throws E185, and
+# Vim blocks on a "Press ENTER" prompt at every startup. This test installs the
+# plugins from scratch and asserts Vim then starts completely clean.
+#
+# It deliberately does a NO-CACHE, full install on every run: that doubles as a
+# link-rot canary for the deprecated upstreams (if one of the old GitHub repos
+# disappears, the clone — and this test — fails loudly). Because that is slow
+# and network-bound, it is meant to run on a schedule (monthly), not per-push.
+#
+# Network note: in a restricted sandbox where github.com is only reachable for
+# the in-scope repo via a git relay, run with GIT_CONFIG_GLOBAL=/dev/null so the
+# plugin clones use plain HTTPS. On GitHub Actions (open network) it's a no-op.
+set -euo pipefail
+
+die() { echo "CI error: $*" >&2; exit 1; }
+
+command -v vim  >/dev/null 2>&1 || die "vim not installed"
+command -v git  >/dev/null 2>&1 || die "git not installed"
+command -v tmux >/dev/null 2>&1 || die "tmux not installed"
+REPO="$PWD"
+VIMRC="$REPO/.vimrc"
+[ -f "$VIMRC" ] || die "no .vimrc in $REPO"
+echo "== $(vim --version | head -1) =="
+
+# Isolated HOME so the real ~/.vim is never touched and the run is reproducible.
+HOME_DIR="$(mktemp -d)"
+SOCK="ci_vim_e2e_$$"
+cleanup() {
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  rm -rf "$HOME_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$HOME_DIR/.vim/bundle" "$HOME_DIR/.vim/undo" "$HOME_DIR/tmp"
+cp "$VIMRC" "$HOME_DIR/.vimrc"
+[ -d "$REPO/.vim/template" ] && cp -r "$REPO/.vim/template" "$HOME_DIR/.vim/template"
+
+# ---------------------------------------------------------------------------
+# Install: neobundle itself, then every plugin declared in .vimrc.
+# ---------------------------------------------------------------------------
+# NeoBundle's own headless installer (`vim -c NeoBundleInstall!`) is unreliable,
+# so we reproduce its end state directly: clone each `owner/repo` into
+# ~/.vim/bundle/<repo-tail>, exactly where NeoBundle would put it. The plugin
+# list is parsed from .vimrc so the test never drifts from the real config.
+echo "== cloning NeoBundle =="
+git clone --depth 1 https://github.com/Shougo/neobundle.vim \
+  "$HOME_DIR/.vim/bundle/neobundle.vim" >/dev/null 2>&1 ||
+  die "failed to clone neobundle.vim"
+
+# Every `NeoBundle`/`NeoBundleFetch`/`NeoBundleLazy 'owner/repo'` line -> owner/repo.
+mapfile -t repos < <(
+  grep -oE "^[[:space:]]*NeoBundle(Fetch|Lazy)?[[:space:]]+['\"][^'\"]+['\"]" "$VIMRC" |
+    sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/" |
+    grep -v '^Shougo/neobundle.vim$' |
+    sort -u
+)
+[ "${#repos[@]}" -gt 0 ] || die "parsed zero plugins from .vimrc (parser broke?)"
+echo "== installing ${#repos[@]} plugins from .vimrc =="
+
+fails=()
+for repo in "${repos[@]}"; do
+  name="${repo##*/}"
+  dest="$HOME_DIR/.vim/bundle/$name"
+  if git clone --depth 1 "https://github.com/$repo" "$dest" >/dev/null 2>&1; then
+    echo "  ok   $repo"
+  else
+    echo "  FAIL $repo"
+    fails+=("$repo")
+  fi
+done
+[ "${#fails[@]}" -eq 0 ] || die "plugin clone failed (link rot?): ${fails[*]}"
+
+# vimproc ships C that NeoBundle compiles via a build hook; do the same so the
+# vimproc-backed features don't warn at runtime.
+if [ -f "$HOME_DIR/.vim/bundle/vimproc/make_unix.mak" ]; then
+  echo "== building vimproc =="
+  ( cd "$HOME_DIR/.vim/bundle/vimproc" && make -f make_unix.mak >/dev/null 2>&1 ) &&
+    echo "  vimproc.so: $(find "$HOME_DIR/.vim/bundle/vimproc" -name '*.so' -printf '%f\n')" ||
+    echo "  warning: vimproc build failed (continuing; startup check is authoritative)"
+fi
+
+# ---------------------------------------------------------------------------
+# Assert 1 (headless): sourcing .vimrc produces no error messages, the
+# colorscheme applied, and representative plugins loaded.
+# ---------------------------------------------------------------------------
+echo "== headless startup check =="
+msgs="$HOME_DIR/messages.txt"
+HOME="$HOME_DIR" vim -N -u "$HOME_DIR/.vimrc" \
+  -c 'set nomore' \
+  -c "redir! > $msgs" \
+  -c 'silent messages' \
+  -c 'silent echo "COLORSCHEME=".(exists("g:colors_name")?g:colors_name:"none")' \
+  -c 'silent echo "UNITE=".(exists(":Unite")?"loaded":"missing")' \
+  -c 'silent echo "NEOCOMPL=".(exists(":NeoComplCacheEnable")?"loaded":"missing")' \
+  -c 'redir END' -c 'qall!' </dev/null >/dev/null 2>&1 || die "vim exited non-zero on startup"
+
+echo "---- :messages ----"; cat "$msgs"; echo "-------------------"
+if grep -nE "E[0-9]{2,}:|Not an editor command|Unknown function|Cannot find color scheme|Error detected" "$msgs"; then
+  die "startup produced Vim errors (see :messages above)"
+fi
+grep -q "COLORSCHEME=solarized" "$msgs" || die "solarized colorscheme not applied"
+grep -q "UNITE=loaded"          "$msgs" || die "unite.vim did not load"
+grep -q "NEOCOMPL=loaded"       "$msgs" || die "neocomplcache did not load"
+echo "== headless startup clean (no errors, plugins + colorscheme loaded) =="
+
+# ---------------------------------------------------------------------------
+# Assert 2 (real terminal): the original symptom was a blocking "Press ENTER"
+# prompt and an error wall instead of the buffer. Drive Vim in a real tmux
+# terminal and confirm it lands on a normal editing screen with neither.
+# ---------------------------------------------------------------------------
+echo "== real-terminal startup check =="
+tmux -L "$SOCK" new-session -d -x 120 -y 40 \
+  "env HOME='$HOME_DIR' TERM=xterm-256color vim -N -u '$HOME_DIR/.vimrc'" ||
+  die "failed to start tmux session"
+
+screen=""
+for _ in $(seq 1 50); do
+  screen="$(tmux -L "$SOCK" capture-pane -p 2>/dev/null || true)"
+  # The ruler set by .vimrc's statusline shows once the buffer is up.
+  printf '%s\n' "$screen" | grep -qE '\[No Name\]|0,0-1|VIM - Vi IMproved' && break
+  sleep 0.1
+done
+if printf '%s\n' "$screen" | grep -qiE 'Press ENTER|Not an editor command|E[0-9]{2,}:|Unknown function'; then
+  echo "---- pane ----"; printf '%s\n' "$screen" >&2
+  die "Vim showed an error / Press-ENTER prompt on real-terminal startup"
+fi
+printf '%s\n' "$screen" | grep -qE '\[No Name\]|VIM - Vi IMproved' ||
+  { echo "---- pane ----"; printf '%s\n' "$screen" >&2; die "Vim did not reach a normal startup screen"; }
+tmux -L "$SOCK" send-keys ':qa!' Enter
+echo "== real-terminal startup clean (normal screen, no Press-ENTER) =="
+
+echo "PASS"

--- a/bin/mkworld.sh
+++ b/bin/mkworld.sh
@@ -18,6 +18,13 @@ if [ ! -d ~/.tmux ]; then
     git clone "https://github.com/tmux-plugins/tpm" ~/.tmux/plugins/tpm
 fi
 
+# Vim (legacy .vimrc): fetch the NeoBundle plugin manager, tracked as a
+# submodule under .vim/bundle/. With it present, the first `vim` launch runs
+# NeoBundleCheck to install the remaining plugins instead of erroring on every
+# NeoBundle command. (.vimrc also self-bootstraps neobundle at launch; this just
+# makes it available up front, at install time.)
+git -C "$BASE_DIR" submodule update --init --recursive
+
 # Make brew-installed tools (e.g. lefthook) available on PATH
 if [ -x "/opt/homebrew/bin/brew" ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"


### PR DESCRIPTION
## Summary

The legacy NeoBundle-based `.vimrc` errored on every startup (E117/E492/E185 + a blocking "Press ENTER") whenever neobundle and its plugins weren't installed, because nothing ever bootstrapped the plugin manager. This makes the old Vim self-healing and regression-proof: it auto-installs / degrades gracefully, and gains e2e coverage so the startup never silently breaks again.

## Changes

- **`.vimrc`** — auto-clone neobundle on a fresh machine (skipped when offline, git missing, or `$VIM_NO_BOOTSTRAP` set), then the existing `NeoBundleCheck` installs the rest. The whole plugin block is guarded behind the manager actually being present, and `silent! colorscheme solarized` is used, so a plugin-less machine degrades to a clean bare Vim instead of an error wall.
- **`bin/mkworld.sh`** — `git submodule update --init --recursive` so the neobundle submodule under `.vim/bundle/` is provisioned at install time (complements the launch-time self-bootstrap).
- **`bin/ci_vim_guard_test.sh`** (new) — fast, network-free e2e: asserts the no-plugin path starts clean (headless: no error messages, `NeoBundle` command absent; real tmux terminal: normal screen, no Press-ENTER). Wired into a per-push `vim_guard_test` job in `ci.yml`.
- **`bin/ci_vim_loading_test.sh`** (new) — full-install e2e: clones neobundle, installs every plugin parsed from `.vimrc`, builds vimproc, then asserts a clean startup (no errors, solarized + unite + neocomplcache loaded). Runs monthly + on demand via `.github/workflows/vim-monthly.yml`; the uncached full clone doubles as a link-rot canary for the deprecated upstreams.

## Verification

- `bin/ci_vim_guard_test.sh` — green; verified red-first by disabling the `.vimrc` guard (fails with "vim exited non-zero with no plugins"), then restored.
- `bin/ci_vim_loading_test.sh` — green: installs 26 plugins, builds `vimproc_linux64.so`, headless + real-terminal startup both clean.
- Confirmed all three `.vimrc` paths by hand: guard (no plugins → no errors, no solarized), bootstrap (first launch clones neobundle), plugins-present (solarized + unite loaded).
- `mkworld.sh` submodule step run locally → neobundle checked out at the pinned commit, working tree clean.
- `./bin/lint_shell.sh`, `lint_config.sh`, `lint_actions.sh`, `lint_editorconfig.sh`, `./bin/run_tests.sh` (80 bats), and lefthook pre-commit/commit-msg/pre-push all pass.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none


---
_Generated by [Claude Code](https://claude.ai/code/session_012h14coMJcCs3wqoXyirMpT)_