### PR TITLE
test(ci): add nvim config guard and starship prompt e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
       - name: e2e for the status bar and dynamic window/pane formats
         run: ./bin/ci_tmux_status_test.sh
 
+      - name: Starship prompt e2e (render in a real terminal, assert segments)
+        run: ./bin/ci_starship_test.sh
+
       - name: Interactive e2e for the g repo-jump command (ghq -> fzf -> cd)
         run: ./bin/ci_g_command_test.sh
 
@@ -125,11 +128,14 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Ensure vim + tmux are present
+      - name: Ensure vim + neovim + tmux are present
         run: |
           set -e
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends vim tmux
+          sudo apt-get install -y --no-install-recommends vim neovim tmux
 
       - name: Legacy .vimrc guard (no-plugin startup must be clean)
         run: ./bin/ci_vim_guard_test.sh
+
+      - name: Neovim config guard (pure-Lua config loads clean, no plugins)
+        run: ./bin/ci_nvim_guard_test.sh

--- a/bin/ci_nvim_guard_test.sh
+++ b/bin/ci_nvim_guard_test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Fast guard test for the Neovim config: on a machine with NO plugins installed
+# and no network, the hand-edited Lua config (config/nvim/lua/kimoto/
+# basic_config.lua) must load cleanly in a real headless nvim and actually apply
+# the options it sets.
+#
+# Scope note: init.lua's second line, require('kimoto/setup_plugin'), curls
+# vim-jetpack from GitHub and pulls dozens of plugins on first start, and the
+# per-plugin requires that follow it (lualine, gitsigns, telescope, ...) all need
+# those plugins present. None of that is hermetic, so a full init.lua startup
+# can't run on every push (that is the job of a monthly full-install test, the
+# nvim analogue of ci_vim_loading_test.sh). What we CAN guard cheaply is the
+# pure-config layer we actually hand-edit: basic_config.lua is plain
+# vim.opt/keymap Lua with no plugin dependency. This loads exactly that module
+# (via a minimal init that only adds config/nvim to the runtimepath) and asserts
+# both that it produces no Lua/Vim errors AND that its options really took effect
+# — a typo'd option name would otherwise fail silently. This is the nvim analogue
+# of ci_vim_guard_test.sh.
+set -euo pipefail
+
+die() { echo "CI error: $*" >&2; exit 1; }
+
+# Prefer a Homebrew nvim (newer) when the shellenv is available.
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+elif [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+command -v nvim >/dev/null 2>&1 || die "nvim not installed"
+REPO="$PWD"
+CONFIG="$REPO/config/nvim/lua/kimoto/basic_config.lua"
+[ -f "$CONFIG" ] || die "no basic_config.lua at $CONFIG"
+echo "== $(nvim --version | head -1) =="
+
+# Isolated HOME + XDG dirs: even though we never require setup_plugin (the
+# network bootstrap), point nvim's config/data/state/cache at a throwaway tree so
+# a stray write can't touch the real environment and the run is reproducible.
+HOME_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$HOME_DIR" 2>/dev/null || true; }
+trap cleanup EXIT
+export XDG_CONFIG_HOME="$HOME_DIR/.config"
+export XDG_DATA_HOME="$HOME_DIR/.local/share"
+export XDG_STATE_HOME="$HOME_DIR/.local/state"
+export XDG_CACHE_HOME="$HOME_DIR/.cache"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
+
+# Minimal init that loads ONLY the pure-config module — not init.lua, so the
+# jetpack curl and the per-plugin requires never run.
+INIT="$HOME_DIR/init.lua"
+cat > "$INIT" <<EOF
+vim.opt.runtimepath:append('$REPO/config/nvim')
+require('kimoto/basic_config')
+EOF
+
+# Headless: source the config, then dump :messages and the resulting option
+# values into a file we can assert on.
+msgs="$HOME_DIR/messages.txt"
+HOME="$HOME_DIR" nvim --headless -u "$INIT" \
+  -c 'set nomore' \
+  -c "redir! > $msgs" \
+  -c 'silent messages' \
+  -c 'silent echo "TABSTOP=" . &tabstop' \
+  -c 'silent echo "SHIFTWIDTH=" . &shiftwidth' \
+  -c 'silent echo "EXPANDTAB=" . (&expandtab ? "on" : "off")' \
+  -c 'silent echo "RELATIVENUMBER=" . (&relativenumber ? "on" : "off")' \
+  -c 'silent echo "IGNORECASE=" . (&ignorecase ? "on" : "off")' \
+  -c 'redir END' -c 'qall!' </dev/null >/dev/null 2>&1 ||
+  die "nvim exited non-zero loading basic_config.lua"
+
+echo "---- :messages ----"; cat "$msgs"; echo "-------------------"
+
+# 1) No Lua/Vim errors surfaced while sourcing the config.
+if grep -nE "E[0-9]{2,}:|Error detected|Unknown function|module '.*' not found|attempt to" "$msgs"; then
+  die "basic_config.lua produced errors on load (the guard regressed)"
+fi
+
+# 2) The options it sets actually took effect — proves the file really loaded and
+#    that no option name silently no-op'd.
+grep -q "TABSTOP=2"         "$msgs" || die "expected tabstop=2 (basic_config did not apply)"
+grep -q "SHIFTWIDTH=2"      "$msgs" || die "expected shiftwidth=2"
+grep -q "EXPANDTAB=on"      "$msgs" || die "expected expandtab on"
+grep -q "RELATIVENUMBER=on" "$msgs" || die "expected relativenumber on"
+grep -q "IGNORECASE=on"     "$msgs" || die "expected ignorecase on"
+
+echo "PASS"

--- a/bin/ci_starship_test.sh
+++ b/bin/ci_starship_test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Interactive end-to-end test for the Starship prompt: drives a real terminal via
+# tmux send-keys + capture-pane (the TUI analogue of a browser e2e) and asserts
+# on what Starship actually renders.
+#
+# .zshrc only sets a *fallback* zsh PROMPT; the real prompt is Starship, brought
+# up by sheldon as `_evalcache starship init zsh` (config/sheldon/plugins.toml).
+# Three things can only be proven by rendering it for real:
+#   1. Starship — not the fallback PROMPT — is what reaches the screen. The
+#      fallback has no date; config/starship.toml enables the [time] module
+#      (format '%Y-%m-%d %T'), so a rendered timestamp is an unambiguous
+#      "Starship is live" signal.
+#   2. the [directory] module reflects $PWD: started in a uniquely-named dir, the
+#      prompt shows that dir name.
+#   3. the `px` helper in .zshrc round-trips STARSHIP_CONFIG between the main and
+#      sub configs (starship.toml <-> starship_sub.toml), the documented way to
+#      switch prompt layouts.
+#
+# Like ci_tmux_interactive_test.sh, this needs a Starship install and the
+# repo's ~/.config (symlinked by mkworld); it runs in the same CI job, after the
+# loading tests.
+set -euo pipefail
+
+die() { echo "CI error: $*" >&2; exit 1; }
+
+# Prefer a Homebrew zsh/tmux/starship (newer) when the shellenv is available.
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+elif [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+command -v tmux     >/dev/null 2>&1 || die "tmux not installed"
+command -v zsh      >/dev/null 2>&1 || die "zsh not installed"
+command -v starship >/dev/null 2>&1 || die "starship not installed (prompt is rendered by it)"
+ZSH_BIN="$(command -v zsh)"
+REPO="$PWD"
+[ -f "$REPO/.zshrc" ] || die "no .zshrc in $REPO"
+[ -f "$REPO/config/starship.toml" ] || die "no config/starship.toml in $REPO"
+[ -f "$REPO/config/starship_sub.toml" ] || die "no config/starship_sub.toml in $REPO"
+echo "== $(tmux -V), $("$ZSH_BIN" --version), $(starship --version | head -1) =="
+
+SOCK="ci_starship_e2e_$$"
+# A uniquely-named start directory so the [directory] segment is unambiguous: the
+# marker is the final path component, which Starship always shows (it truncates
+# leading components, never the tail).
+WORK="$(mktemp -d)/starship_e2e_zone"
+mkdir -p "$WORK"
+cleanup() {
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  rm -rf "$(dirname "$WORK")" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Poll capture-pane until $1 (a grep -E pattern) appears, or time out. Sampling
+# in a loop keeps the test as fast as the shell on a quick runner and as
+# forgiving as needed on a slow one.
+wait_for() {
+  local pattern="$1" tries="${2:-80}" i=0
+  while [ "$i" -lt "$tries" ]; do
+    if tmux -L "$SOCK" capture-pane -p 2>/dev/null | grep -qE "$pattern"; then
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 0.1
+  done
+  echo "---- pane contents at timeout ----" >&2
+  tmux -L "$SOCK" capture-pane -p >&2 || true
+  die "timed out waiting for: $pattern"
+}
+
+# Launch an interactive zsh in a real terminal, started inside the marker dir.
+# Same conventions as ci_tmux_interactive_test.sh: ZDOTDIR points at the repo, CI
+# is cleared so .zshrc does not enable err_exit, the sync-check is silenced.
+tmux -L "$SOCK" new-session -d -x 200 -y 50 -c "$WORK" \
+  "env CI= ZDOTDIR='$REPO' DOTFILES_NO_SYNC_CHECK=1 TERM=xterm-256color '$ZSH_BIN' -i" ||
+  die "failed to start tmux session"
+
+# 1) Starship is the live prompt (not the fallback): its [time] module renders a
+#    timestamp the fallback PROMPT never produces.
+wait_for '[0-9]{4}-[0-9]{2}-[0-9]{2}'
+echo "== Starship prompt is live (time module rendered) =="
+
+# 2) The [directory] module reflects $PWD — the marker dir name is on screen.
+wait_for 'starship_e2e_zone'
+echo "== directory module reflects \$PWD =="
+
+# 3) `px` round-trips STARSHIP_CONFIG main <-> sub. STARSHIP_CONFIG starts unset,
+#    so the first px selects the sub config and the second returns to the main
+#    one. Each value is printed with a unique marker so the assertion can only
+#    match the line we just produced, not earlier scrollback.
+# shellcheck disable=SC2016  # single-quoted on purpose: zsh in the pane must
+# expand $STARSHIP_CONFIG and run px, not this shell.
+tmux -L "$SOCK" send-keys 'px; print "__CFG1__${STARSHIP_CONFIG}"' Enter
+wait_for '__CFG1__.*/starship_sub\.toml'
+echo "== px (1st) selected the sub config =="
+
+# shellcheck disable=SC2016
+tmux -L "$SOCK" send-keys 'px; print "__CFG2__${STARSHIP_CONFIG}"' Enter
+wait_for '__CFG2__.*/starship\.toml'
+echo "== px (2nd) returned to the main config =="
+
+tmux -L "$SOCK" send-keys C-c
+echo "PASS"


### PR DESCRIPTION
## Summary

Add two end-to-end checks, each the analogue of an existing one: an nvim config guard (mirror of `ci_vim_guard_test.sh`) and a Starship prompt e2e (same real-terminal approach as `ci_tmux_interactive_test.sh` / the `g` command test).

## Changes

- **`bin/ci_nvim_guard_test.sh`** — nvim counterpart to `ci_vim_guard_test.sh`. Loads the hand-edited pure-Lua config (`config/nvim/lua/kimoto/basic_config.lua`) in a real headless nvim with no plugins and no network, then asserts both that it produces no Lua/Vim errors **and** that its options actually took effect (so a typo'd option name can't fail silently). `init.lua`'s jetpack bootstrap + per-plugin requires need the network, so a full startup stays out of the every-push path; this guards the layer edited by hand.
- **`bin/ci_starship_test.sh`** — drives a real terminal via tmux `send-keys` + `capture-pane` and asserts on what Starship renders: the `[time]` module proves Starship (not the fallback `PROMPT`) is live, the `[directory]` module reflects `$PWD`, and the `px` helper round-trips `STARSHIP_CONFIG` between the main and sub configs.
- **`.github/workflows/ci.yml`** — wire both in: starship into the `zsh_loading_test` job after the interactive e2e (where `mkworld` has installed sheldon + starship); nvim guard into the `vim_guard_test` job (apt now also installs `neovim`).

## Verification

- `ci_nvim_guard_test.sh`: ran locally on NVIM v0.9.5 → PASS. TDD red proof: injecting a Lua error and changing an option value each fail the check; revert → green.
- `ci_starship_test.sh`: the sandbox proxy blocks `sheldon source`'s plugin fetch, so the full sheldon path can't run locally. Verified the three assertions against **real Starship 1.25.1** output via an equivalent harness using the same config-discovery path CI uses (`~/.config/starship.toml`, direct `starship init zsh`) → all 4 assertions green. Also confirmed `capture-pane` captures the `[time]` segment despite its `style = "hidden"`. The script itself first runs the genuine sheldon path in CI.
- `./bin/lint_shell.sh`, `./bin/lint_editorconfig.sh`, `./bin/lint_config.sh`, and the bats suite (80 tests) all pass via lefthook on commit.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019r8LoBGCMskN3yZ2J6zUjp)_