### PR TITLE
chore(tmux): remove tmux-which-key; restore C-t Space to next-layout

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -90,7 +90,6 @@ setw -g window-status-separator ""
 set-environment -g PATH "/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:/bin:/usr/bin"
 run '~/.tmux/plugins/tpm/tpm'
 
-# Restore default Space → next-layout (tmux-which-key overrides this)
 bind-key Space next-layout
 
 # Solarized pane styling (after tpm to override plugin defaults)

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -54,7 +54,6 @@ set -g @tpm_plugins ' \
   laktak/extrakto \
   sainnhe/tmux-fzf \
   nhdaly/tmux-better-mouse-mode \
-  alexwforsythe/tmux-which-key \
   timvw/tmux-assistant-resurrect \
 '
 
@@ -90,6 +89,9 @@ setw -g window-status-separator ""
 # https://github.com/tmux-plugins/tpm/blob/master/docs/tpm_not_working.md
 set-environment -g PATH "/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:/bin:/usr/bin"
 run '~/.tmux/plugins/tpm/tpm'
+
+# Restore default Space → next-layout (tmux-which-key overrides this)
+bind-key Space next-layout
 
 # Solarized pane styling (after tpm to override plugin defaults)
 set-option -g pane-border-status top


### PR DESCRIPTION
## Summary

Remove `tmux-which-key` plugin, which was overriding `C-t Space` with a menu display, and restore tmux's default `next-layout` binding.

## Changes

- Remove `alexwforsythe/tmux-which-key` from `@tpm_plugins` in `.tmux.conf`
- Add `bind-key Space next-layout` after `run tpm` to override any residual binding

## Verification

- After `tmux source-file ~/.tmux.conf`, confirmed `tmux list-keys | grep "prefix.*Space"` returns `next-layout`

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)