### PR TITLE
docs(ci): fix stale brew cache-key comment (-fzf-v2 -> -fzf-v3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             /opt/homebrew
             /home/linuxbrew/.linuxbrew
-          # The -fzf-v2 suffix is part of the key on purpose: fzf is installed
+          # The -fzf-v3 suffix is part of the key on purpose: fzf is installed
           # into this cache below but is not in Brewfile.basic, so the suffix
           # forces a rebuild that bakes it in. Bump the vN to evict a bad cache
           # or when the set of extra brew installs changes. (tmux IS in


### PR DESCRIPTION
## Summary

Follow-up to #59. The brew cache key is `…-fzf-v3`, but the explanatory comment still says `-fzf-v2` — the cold-run commit bumped the key suffix and the comment wasn't synced before #59 was squash-merged. This corrects the comment so it matches the actual key. No functional change.

## Changes

- `.github/workflows/ci.yml`: comment `The -fzf-v2 suffix …` → `The -fzf-v3 suffix …` (line 57), matching the key on line 62.

## Verification

- `bin/lint_actions.sh` and `bin/lint_config.sh .github/workflows/ci.yml`: clean.
- Diff is a single comment line; no behavior change.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Follow-up to #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfbRMRKwFkvMKnU4rAYrys)_