### PR TITLE
fix(vim): inherit terminal background to match Ghostty color

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -276,6 +276,7 @@ syntax enable
 set background=dark
 filetype plugin indent on " Required!
 silent! colorscheme solarized
+highlight Normal ctermbg=NONE guibg=NONE
 
 if s:has_neobundle
 	NeoBundleCheck


### PR DESCRIPTION
## Summary

`altercation/vim-colors-solarized` only sets `guifg`/`guibg` when `has("gui_running")` is true, so `set termguicolors` cannot fix the background mismatch. Setting `ctermbg=NONE guibg=NONE` makes Vim inherit the terminal background directly, eliminating the slight color difference with Ghostty's Iterm2 Solarized Dark theme.

## Changes

- `.vimrc`: add `highlight Normal ctermbg=NONE guibg=NONE` after colorscheme load

## Verification

- Opened Vim in Ghostty with `background-opacity=1.0` — background matches terminal background exactly
- Syntax highlighting colors (solarized palette) render correctly

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)