### PR TITLE
fix(nvim): patch jetpack.vim for Neovim 0.12+ and switch to NvChad colorizer

### DIFF
--- a/config/nvim/lua/kimoto/setup_plugin.lua
+++ b/config/nvim/lua/kimoto/setup_plugin.lua
@@ -5,6 +5,19 @@ if vim.fn.filereadable(jetpackfile) == 0 then
   vim.fn.system(string.format('curl -fsSLo %s --create-dirs %s', jetpackfile, jetpackurl))
 end
 
+-- Neovim 0.12+ defines vim.list as a table module; the upstream jetpack.vim
+-- uses `local list = vim.list or function...` which picks up the table and
+-- then fails when cast() tries to call it. Patch the assignment to guard with
+-- type() so the fallback identity function is used instead.
+local lines = vim.fn.readfile(jetpackfile)
+for i, line in ipairs(lines) do
+  lines[i] = line:gsub(
+    'local list = vim%.list or function',
+    'local list = type(vim.list) == "function" and vim.list or function'
+  )
+end
+vim.fn.writefile(lines, jetpackfile)
+
 vim.cmd('packadd vim-jetpack')
 
 require('jetpack.paq') {
@@ -37,7 +50,7 @@ require('jetpack.paq') {
 
   {'numToStr/Comment.nvim', config = function() require('Comment').setup() end},
 
-  'norcalli/nvim-colorizer.lua', -- カーソル下と同じ単語を強調
+  'NvChad/nvim-colorizer.lua', -- カーソル下と同じ単語を強調
 
   'dinhhuy258/git.nvim', -- like fugitive.vim
   'lewis6991/gitsigns.nvim', -- git statusを表示


### PR DESCRIPTION
## Summary

Fixes nvim startup crash (E5113) on Neovim 0.12+ and eliminates a deprecation warning that would become a hard error in Nvim 0.13.

## Changes

- `setup_plugin.lua`: after downloading `jetpack.vim`, patch `local list = vim.list or function...` to guard with `type()` — Neovim 0.12+ defines `vim.list` as a table module, which caused `cast()` to fail on startup
- `setup_plugin.lua`: replace unmaintained `norcalli/nvim-colorizer.lua` with `NvChad/nvim-colorizer.lua` (API-compatible fork) to fix `vim.tbl_flatten` deprecation warning

## Verification

- Confirmed E5113 error gone: `nvim --headless -c "q"` exits cleanly
- Confirmed zero warnings: `checkhealth vim.deprecated` reports 0 warnings after fix

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none