### PR TITLE
feat(tmux): add prompt navigation and OSC 133 shell integration

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -9,6 +9,8 @@ unbind-key -T copy-mode-vi v
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
 unbind -T copy-mode-vi MouseDragEnd1Pane
+bind-key -T copy-mode-vi '[' send-keys -X previous-prompt
+bind-key -T copy-mode-vi ']' send-keys -X next-prompt
 
 bind-key Right join-pane -t :+
 bind-key Left join-pane -t :-

--- a/.zshrc
+++ b/.zshrc
@@ -347,6 +347,34 @@ update_tmux_window () {
 add-zsh-hook chpwd update_tmux_window
 add-zsh-hook precmd update_tmux_window
 
+# Emit OSC 133;A so tmux can track prompt positions (next-prompt/previous-prompt in copy mode).
+# Prepend to PROMPT (after Starship sets it) so the mark lands at the exact moment zsh draws
+# the prompt, avoiding cursor-position races with Starship's own terminal sequences.
+_tmux_prompt_mark() {
+  [[ -n "$TMUX" ]] || return
+  PROMPT=$'%{\e]133;A\a%}'"$PROMPT"
+}
+add-zsh-hook precmd _tmux_prompt_mark
+
+# Ship a dotfiles PR: push → create PR → auto-merge → wait for MERGED → switch to main.
+# Stays on the branch until the PR actually merges, so symlinked dotfiles never revert mid-flight.
+dotfiles-ship() {
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD) || return 1
+  git push -u origin HEAD || return 1
+  gh pr create --fill || return 1
+  gh pr merge --auto --merge || return 1
+  echo "Waiting for CI..."
+  gh pr checks --watch
+  echo "Waiting for merge..."
+  until [[ $(gh pr view --json state -q '.state') == "MERGED" ]]; do
+    sleep 3
+  done
+  git switch main
+  git pull
+  git branch -d "$branch"
+}
+
 #=====================
 # load other settings
 #=====================


### PR DESCRIPTION
## Summary

Add OSC 133 shell integration and copy-mode keybindings so tmux can track shell prompt positions and jump between them in copy mode.

## Changes

- `.tmux.conf`: bind `[` → `previous-prompt` and `]` → `next-prompt` in copy-mode-vi
- `.zshrc`: add `_tmux_prompt_mark` precmd hook that prepends OSC 133;A to `PROMPT` after Starship sets it, ensuring the mark lands at the exact moment zsh draws the prompt (avoids cursor-position races with Starship's terminal sequences)
- `.zshrc`: add `dotfiles-ship` helper — push → create PR with auto-merge → wait for MERGED state → switch to main, so symlinked dotfiles never revert mid-flight

## Verification

- After `source ~/.zshrc`, enter tmux copy mode and press `[` to confirm cursor jumps to the previous prompt line.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
