### PR TITLE
docs(agents): clarify language rule coexists with respond-in-Japanese

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,4 +74,5 @@ truth, so the two never diverge.
 
 ### Language
 
-English for public artifacts (commits, PRs, comments, docs); Japanese in chat.
+"Respond in Japanese" applies to chat replies, not artifact content. Commits,
+PRs, comments, and docs are file content — always English; chat stays Japanese.


### PR DESCRIPTION
## Summary

The global `language: Japanese` Claude setting injects "Always respond in Japanese", which kept overriding the English-artifacts rule (PR bodies were being written in Japanese). Reframe the language rule so it coexists with that setting instead of conflicting.

## Changes

- `AGENTS.md`: rewrite the Language section around a surface distinction — "respond in Japanese" governs chat replies, while commits/PRs/comments/docs are file content and stay English. (`CLAUDE.md` is a symlink, so it updates too.)

## Verification

- Confirmed `~/.claude/settings.json` has `"language": "Japanese"` as the source of the override.
- Wording reviewed for length and clarity; kept to two lines under the 120-col limit.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)