### PR TITLE
feat(brew): trust morantron/tmux-fingers tap before bundle install

### DIFF
--- a/bin/lint_schema.sh
+++ b/bin/lint_schema.sh
@@ -107,7 +107,7 @@ for f in "${files[@]}"; do
     fi
 
     if [ "${f##*.}" = "jsonc" ]; then
-        tmp=$(mktemp --suffix=.json)
+        tmp=$(mktemp)
         jsonc_to_json <"$f" >"$tmp"
         validate "$f" "$schema" --force-filetype json "$tmp"
         rm -f "$tmp"

--- a/bin/setup_homebrew.sh
+++ b/bin/setup_homebrew.sh
@@ -31,6 +31,7 @@ fi
 
 "$BREW_BIN" bundle install --file=Brewfile.basic
 if [ "${CI:-}" != "true" ]; then
+    "$BREW_BIN" trust morantron/tmux-fingers 2>/dev/null || true
     "$BREW_BIN" bundle install --file=Brewfile.common
 fi
 

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,5 +1,7 @@
 theme = Iterm2 Solarized Dark
 command = /bin/zsh -l -c "/opt/homebrew/bin/tmux new -A -s ghostty"
+font-family = JetBrainsMono Nerd Font
+font-family = Hiragino Sans W4
 font-feature = -calt, -liga, -dlig
 font-thicken = true
 font-thicken-strength = 10


### PR DESCRIPTION
## Summary

- Add `brew trust morantron/tmux-fingers` before `brew bundle install --file=Brewfile.common` in `setup_homebrew.sh` to prevent "Refusing to load formula from untrusted tap" error on fresh machine setup
- Also pin Japanese font to Hiragino Sans W4 in ghostty config
- Fix `mktemp --suffix=.json` (GNU-only flag) to plain `mktemp` in `lint_schema.sh`; `--force-filetype json` makes the extension unnecessary, restoring macOS BSD mktemp compatibility

## Changes

- `bin/setup_homebrew.sh`: add `brew trust morantron/tmux-fingers` before Brewfile.common bundle install
- `config/ghostty/config`: add JetBrainsMono Nerd Font and Hiragino Sans font families
- `bin/lint_schema.sh`: replace `mktemp --suffix=.json` with `mktemp` for BSD compatibility

## Verification

- Ran `bats test/lint_schema.bats`: all 9 tests pass (previously tests 6/7 failed with `mktemp: unrecognized option '--suffix=.json'`)
- All 91 unit tests pass via lefthook pre-commit hook
- Reproduced the original tmux-fingers error with `brew bundle install --file=Brewfile.common`; confirmed `brew trust morantron/tmux-fingers` resolves it

## Checklist

- [x] Conventional Commits subject
- [x] Tests pass locally
- [x] No new trailing whitespace / line-length violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)