### PR TITLE
chore: remove procs in favour of plain ps

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -176,7 +176,6 @@ alias cat='bat'
 alias less='bat --pager=less'
 alias curl='curlie' # for pretty-print
 alias top='btop'
-alias ps='procs'
 alias ping='gping'
 alias dig='doggo'
 alias grep='grep --color=auto'

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -101,8 +101,6 @@ brew "netcat"
 brew "nmap"
 # SSL/TLS VPN implementing OSI layer 2 or 3 secure network extension
 brew "openvpn"
-# Modern replacement for ps written in Rust
-brew "procs"
 # Generic machine emulator and virtualizer
 brew "qemu"
 # Pin/lint GitHub Actions workflows to immutable commit SHAs


### PR DESCRIPTION
## Summary

Remove `procs` which defaults to paging behaviour, diverging too much from standard `ps` usage.

## Changes

- `Brewfile.common`: remove `brew "procs"`
- `.zshrc`: remove `alias ps='procs'`

## Verification

Hooks pass locally (lefthook pre-commit: all checks green).

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
