### PR TITLE
fix(brew): invalidate bundle-check cache on Cellar or Brewfile change

### DIFF
--- a/bin/brew_bundle_check.sh
+++ b/bin/brew_bundle_check.sh
@@ -48,6 +48,19 @@ if [ -f "$stamp" ] && [ -f "$result" ]; then
     fi
 fi
 
+# Invalidate cache if any Brewfile or the Homebrew Cellar changed since last check.
+if [ "$need_check" -eq 0 ]; then
+    cellar=$(brew --cellar 2>/dev/null) || cellar=""
+    for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"}; do
+        [ -e "$check_path" ] || continue
+        mtime=$(stat -f %m "$check_path" 2>/dev/null || echo 0)
+        if [ "$mtime" -gt "$last" ]; then
+            need_check=1
+            break
+        fi
+    done
+fi
+
 if [ "$need_check" -eq 1 ]; then
     missing=()
     for f in "${files[@]}"; do


### PR DESCRIPTION
## Summary

`brew_bundle_check.sh` cached a "missing packages" result for 24h, so the startup warning persisted even after running `brew bundle install`. Cache now also invalidates when the Homebrew Cellar or any checked Brewfile has been modified more recently than the last check stamp.

## Changes

- Add mtime-based cache invalidation: if `$(brew --cellar)` or any Brewfile is newer than the last check stamp, force a re-check regardless of the 24h throttle

## Verification

- Ran `brew bundle check --file=Brewfile.common` → satisfied
- Cleared cache, ran `brew_bundle_check.sh` → no output (cache refreshed clean)
- All 91 unit tests pass (`./bin/run_tests.sh`)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)