### PR TITLE
fix(brew): support GNU stat for mtime on Linux

### DIFF
--- a/bin/brew_bundle_check.sh
+++ b/bin/brew_bundle_check.sh
@@ -53,7 +53,7 @@ if [ "$need_check" -eq 0 ]; then
     cellar=$(brew --cellar 2>/dev/null) || cellar=""
     for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"}; do
         [ -e "$check_path" ] || continue
-        mtime=$(stat -f %m "$check_path" 2>/dev/null || echo 0)
+        mtime=$(stat -f %m "$check_path" 2>/dev/null || stat -c %Y "$check_path" 2>/dev/null || echo 0)
         if [ "$mtime" -gt "$last" ]; then
             need_check=1
             break


### PR DESCRIPTION
## Summary

`brew_bundle_check.sh` used `stat -f %m` to read a file's mtime, which is BSD/macOS syntax. On Linux (GNU coreutils) `stat -f` prints filesystem stats instead, so `$mtime` captured multi-line output and the cache-invalidation comparison failed with `integer expression expected` on every login.

## Changes

- `bin/brew_bundle_check.sh`: fall back to GNU `stat -c %Y` when the BSD `stat -f %m` form fails, so the mtime check works on both macOS and Linux.

## Verification

- `./bin/lint_shell.sh` — clean.
- lefthook pre-commit: shellcheck + 91 unit tests (`bats`) all pass.
- Root cause reproduced on a Linux (xfs) host: `stat -f` emitted filesystem stats, triggering the `[: integer expression expected` errors at login.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
