### PR TITLE
feat(claude): auto-switch to main on SessionEnd when PR merged

### DIFF
--- a/.claude/hooks/auto-main-sync.sh
+++ b/.claude/hooks/auto-main-sync.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-# At SessionEnd: remind the user to switch to main if their branch's PR has merged.
+# At SessionEnd: when the current branch's PR has merged and the working tree is
+# clean, return to main, pull, and delete the merged branch — so the just-merged
+# work lands in the local checkout. Fires once when the session ends, never
+# mid-turn. A dirty tree (or a still-open PR) only prints a reminder; the
+# checkout is left untouched so nothing is switched out from under unsaved work.
 set -uo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || exit 0
 command -v gh >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
 
 current_branch=$(git branch --show-current 2>/dev/null) || exit 0
 [[ -z "$current_branch" || "$current_branch" == "main" ]] && exit 0
@@ -12,7 +17,16 @@ pr_info=$(gh pr view "$current_branch" --json state,number --jq '"#\(.number) \(
 
 case "$pr_info" in
   *MERGED*)
-    echo "[reminder] PR $pr_info for '$current_branch' — run: git switch main && git pull"
+    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+      echo "[reminder] PR $pr_info for '$current_branch' merged, but the working tree is dirty — commit/stash, then: git switch main && git pull"
+      exit 0
+    fi
+    if git switch main >/dev/null 2>&1 && git pull --ff-only >/dev/null 2>&1; then
+      git branch -d "$current_branch" >/dev/null 2>&1 || true
+      echo "[auto-main-sync] PR $pr_info merged — switched to main, pulled, deleted '$current_branch'"
+    else
+      echo "[reminder] PR $pr_info merged, but auto-switch failed — run: git switch main && git pull"
+    fi
     ;;
   *OPEN*)
     echo "[reminder] PR $pr_info for '$current_branch' still open — switch to main after CI passes"

--- a/test/auto_main_sync.bats
+++ b/test/auto_main_sync.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+# Behavioural tests for .claude/hooks/auto-main-sync.sh, the SessionEnd hook that
+# returns a clean feature branch to main once its PR has merged.
+#
+# The hook inspects $CLAUDE_PROJECT_DIR, talks to `gh`, and mutates the checkout
+# (switch/pull/branch -d). Each test runs the real hook against a throwaway git
+# repo wired to a local bare "remote" (no network) and a stub `gh` on PATH whose
+# answer is driven by $FAKE_PR_OUTPUT. Hook output goes to stdout, folded into
+# $output by bats.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  HOOK="$REPO_ROOT/.claude/hooks/auto-main-sync.sh"
+  TMP="$(mktemp -d)"
+
+  # Stub gh: prints $FAKE_PR_OUTPUT, or fails (no PR) when it is empty.
+  mkdir -p "$TMP/bin"
+  cat >"$TMP/bin/gh" <<'EOF'
+#!/bin/bash
+[ -n "${FAKE_PR_OUTPUT:-}" ] || exit 1
+echo "$FAKE_PR_OUTPUT"
+EOF
+  chmod +x "$TMP/bin/gh"
+  export PATH="$TMP/bin:$PATH"
+
+  # A bare remote with main at commit A, plus a feature branch carrying one
+  # commit; the remote's main is advanced to that commit to mimic a merged PR.
+  REPO="$TMP/repo"
+  git init -q --bare "$TMP/remote.git"
+  git -c init.defaultBranch=main clone -q "$TMP/remote.git" "$REPO"
+  git -C "$REPO" config user.email test@example.com
+  git -C "$REPO" config user.name "Test"
+  echo a >"$REPO/file.txt"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: seed"
+  git -C "$REPO" branch -M main          # empty-clone default may not be 'main'
+  git -C "$REPO" push -q -u origin main
+
+  export CLAUDE_PROJECT_DIR="$REPO"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# Put $REPO on a clean feature branch whose work is already on the remote's main
+# (the merged-PR state): local main stays behind, so a later pull fast-forwards.
+on_merged_feature_branch() {
+  git -C "$REPO" switch -q -c feature
+  echo work >>"$REPO/file.txt"
+  git -C "$REPO" commit -qam "feat: work"
+  git -C "$REPO" push -q -u origin feature
+  git -C "$REPO" push -q origin feature:main   # advance remote main -> merged
+}
+
+@test "merged PR on a clean tree: switches to main, pulls, deletes the branch" {
+  on_merged_feature_branch
+  FAKE_PR_OUTPUT="#1 MERGED" run "$HOOK"
+  [ "$status" -eq 0 ]
+  [ "$(git -C "$REPO" branch --show-current)" = "main" ]
+  git -C "$REPO" merge-base --is-ancestor HEAD origin/main   # main pulled up to the merge
+  run git -C "$REPO" rev-parse --verify feature              # branch deleted
+  [ "$status" -ne 0 ]
+}
+
+@test "merged PR but dirty tree: only reminds, never touches the checkout" {
+  on_merged_feature_branch
+  echo dirty >>"$REPO/file.txt"
+  FAKE_PR_OUTPUT="#1 MERGED" run "$HOOK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dirty"* ]]
+  [ "$(git -C "$REPO" branch --show-current)" = "feature" ]
+}
+
+@test "open PR: reminds and stays on the branch" {
+  on_merged_feature_branch
+  FAKE_PR_OUTPUT="#1 OPEN" run "$HOOK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"open"* ]]
+  [ "$(git -C "$REPO" branch --show-current)" = "feature" ]
+}
+
+@test "already on main: silent no-op" {
+  FAKE_PR_OUTPUT="#1 MERGED" run "$HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "no PR for the branch: silent" {
+  git -C "$REPO" switch -q -c feature
+  FAKE_PR_OUTPUT="" run "$HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ "$(git -C "$REPO" branch --show-current)" = "feature" ]
+}


### PR DESCRIPTION
## Summary

The SessionEnd hook only *reminded* the user to switch to main, so a merged branch's work was never reflected in the local checkout until done by hand. Restore the auto-switch behaviour (switch main + pull + delete the merged branch), but keep it at SessionEnd so it fires once per session rather than after every turn.

## Changes

- `.claude/hooks/auto-main-sync.sh`: when the current branch's PR is `MERGED` and the working tree is clean, run `git switch main && git pull --ff-only && git branch -d <branch>`. A dirty tree or a still-open PR only prints a reminder — the checkout is never touched with unsaved work.
- `test/auto_main_sync.bats`: new behavioural tests for the switch, dirty-tree, open-PR, on-main, and no-PR paths (local bare remote + stub `gh`, no network).

## Verification

- TDD: wrote the tests first, confirmed red against the reminder-only hook (switch/dirty cases failed), then green after the change.
- `bats test/auto_main_sync.bats` — 5/5 pass.
- lefthook pre-commit: shellcheck + full bats suite (96 tests) all pass.
- `shellcheck .claude/hooks/auto-main-sync.sh` — clean.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
