### PR TITLE
fix(brew): try GNU stat -c before BSD stat -f for mtime

### DIFF
--- a/bin/brew_bundle_check.sh
+++ b/bin/brew_bundle_check.sh
@@ -53,7 +53,7 @@ if [ "$need_check" -eq 0 ]; then
     cellar=$(brew --cellar 2>/dev/null) || cellar=""
     for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"}; do
         [ -e "$check_path" ] || continue
-        mtime=$(stat -f %m "$check_path" 2>/dev/null || stat -c %Y "$check_path" 2>/dev/null || echo 0)
+        mtime=$(stat -c %Y "$check_path" 2>/dev/null || stat -f %m "$check_path" 2>/dev/null || echo 0)
         if [ "$mtime" -gt "$last" ]; then
             need_check=1
             break


### PR DESCRIPTION
## Summary

`stat -f %m` is macOS BSD stat syntax. On Linux, GNU stat interprets `-f` as `--file-system` (filesystem info mode), so `%m` is treated as a filename argument. This causes verbose filesystem info to be printed to stdout and the command exits 0 — meaning the `||` fallback to `stat -c %Y` never fired, leaving `$mtime` holding a multi-line string and causing `integer expression expected` errors.

Swapping the order — trying GNU stat's `-c %Y` first and falling back to BSD stat's `-f %m` — fixes both platforms.

## Changes

- `bin/brew_bundle_check.sh`: try `stat -c %Y` first; keep `stat -f %m` as the macOS BSD stat fallback

## Verification

Ran the fixed command on Linux:
```
$ stat -c %Y /home/kimoto/dotfiles/Brewfile.basic 2>/dev/null || stat -f %m /home/kimoto/dotfiles/Brewfile.basic 2>/dev/null || echo 0
1782561234
```
Returns a plain integer; `integer expression expected` errors are gone.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Closes the regression introduced in #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)