### PR TITLE
feat(tmux): sync clipboard to local host when copying over SSH

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -44,7 +44,9 @@ if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- 
 set -g default-terminal "xterm-256color"
 set -as terminal-features '*:RGB'
 set -as terminal-features '*:hyperlinks'
+set -as terminal-features '*:clipboard'
 set -as terminal-overrides ',xterm-256color:RGB'
+set -g set-clipboard on
 
 set -g @tpm_plugins ' \
   tmux-plugins/tpm \

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -31,6 +31,7 @@ keybind = alt+digit_5=unbind
 quit-after-last-window-closed = true
 shell-integration = zsh
 shell-integration-features = no-cursor,ssh-env,ssh-terminfo
+clipboard-write = allow
 cursor-opacity = 0.5
 cursor-style-blink = true
 background-opacity = 0.6


### PR DESCRIPTION
## Summary

Enable clipboard sync from a remote SSH tmux session back to the local macOS clipboard via OSC 52 terminal escape sequences.

## Changes

- `.tmux.conf`: add `set -as terminal-features '*:clipboard'` to declare OSC 52 support for all terminals
- `.tmux.conf`: add `set -g set-clipboard on` to relay OSC 52 sequences from nested tmux sessions to the outer terminal
- `config/ghostty/config`: add `clipboard-write = allow` so Ghostty explicitly accepts OSC 52 clipboard writes

## Verification

- Local tmux copy: existing `pbcopy` pipe continues to work unchanged
- Remote SSH + tmux copy: requires a real SSH session to fully verify (local-only testing cannot exercise this path)

How it works:
1. Copy in remote tmux → `set-clipboard on` emits OSC 52 to the outer terminal (SSH pty)
2. Local tmux receives OSC 52 → relays it to Ghostty via `set-clipboard on`
3. Ghostty updates the macOS clipboard

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
