### PR TITLE
feat(vps): expand backup coverage for comprehensive VPS recovery

### DIFF
--- a/bin/vps-backup-dump.sh
+++ b/bin/vps-backup-dump.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Run on the VPS to collect root-owned files into ~/backup-staging/ for rsync pull.
+set -euo pipefail
+
+STAGING="$HOME/backup-staging"
+
+echo "[dump] Preparing $STAGING"
+mkdir -p "$STAGING/systemd" "$STAGING/cron.d" "$STAGING/etc/ssh" \
+         "$STAGING/etc/my.cnf.d" "$STAGING/etc/sysctl.d" \
+         "$STAGING/etc/sudoers.d" "$STAGING/etc/profile.d" \
+         "$STAGING/letsencrypt" "$STAGING/nginx-disabled-vhosts" \
+         "$STAGING/nginx-logs"
+
+echo "[dump] MariaDB full dump..."
+sudo mysqldump --all-databases --single-transaction --routines --events \
+  | gzip > "$STAGING/mariadb-all.sql.gz"
+echo "[dump] MariaDB: $(du -sh "$STAGING/mariadb-all.sql.gz" | cut -f1)"
+if ! zcat "$STAGING/mariadb-all.sql.gz" | tail -3 | grep -q "Dump completed"; then
+  echo "[dump] WARNING: MariaDB dump may be incomplete - check manually!"
+fi
+
+echo "[dump] systemd custom units..."
+sudo cp /etc/systemd/system/*.service "$STAGING/systemd/" 2>/dev/null || true
+sudo cp /etc/systemd/system/*.timer   "$STAGING/systemd/" 2>/dev/null || true
+sudo chown kimoto:users "$STAGING/systemd/"* 2>/dev/null || true
+
+echo "[dump] cron.d..."
+sudo cp -r /etc/cron.d/. "$STAGING/cron.d/" 2>/dev/null || true
+sudo chown -R kimoto:users "$STAGING/cron.d"
+
+echo "[dump] sshd_config..."
+sudo cp /etc/ssh/sshd_config "$STAGING/etc/ssh/"
+sudo chown kimoto:users "$STAGING/etc/ssh/sshd_config"
+
+echo "[dump] MariaDB config..."
+sudo cp /etc/my.cnf.d/server.cnf "$STAGING/etc/my.cnf.d/" 2>/dev/null || true
+sudo chown kimoto:users "$STAGING/etc/my.cnf.d/"* 2>/dev/null || true
+
+echo "[dump] sysctl security config..."
+sudo cp /etc/sysctl.d/99-security.conf "$STAGING/etc/sysctl.d/" 2>/dev/null || true
+sudo chown kimoto:users "$STAGING/etc/sysctl.d/"* 2>/dev/null || true
+
+echo "[dump] sudoers.d..."
+sudo cp -r /etc/sudoers.d/. "$STAGING/etc/sudoers.d/" 2>/dev/null || true
+sudo chown -R kimoto:users "$STAGING/etc/sudoers.d"
+
+echo "[dump] profile.d (custom)..."
+sudo cp /etc/profile.d/mise-system.sh /etc/profile.d/mise.sh "$STAGING/etc/profile.d/" 2>/dev/null || true
+sudo chown kimoto:users "$STAGING/etc/profile.d/"* 2>/dev/null || true
+
+echo "[dump] firewalld rules..."
+sudo firewall-cmd --list-all 2>/dev/null | tee "$STAGING/firewalld-rules.txt" > /dev/null || true
+
+echo "[dump] sshd effective config..."
+sudo sshd -T 2>/dev/null | tee "$STAGING/sshd-T.txt" > /dev/null || true
+
+echo "[dump] letsencrypt certs..."
+sudo cp -r /etc/letsencrypt/. "$STAGING/letsencrypt/" 2>/dev/null || true
+sudo chown -R kimoto:users "$STAGING/letsencrypt"
+
+echo "[dump] nginx disabled vhosts..."
+sudo cp -r /root/nginx-disabled-vhosts/. "$STAGING/nginx-disabled-vhosts/" 2>/dev/null || true
+sudo chown -R kimoto:users "$STAGING/nginx-disabled-vhosts"
+
+echo "[dump] /etc full tarball..."
+sudo tar -czf "$STAGING/etc-all.tar.gz" /etc 2>/dev/null || true
+sudo chown kimoto:users "$STAGING/etc-all.tar.gz" 2>/dev/null || true
+echo "[dump] /etc: $(du -sh "$STAGING/etc-all.tar.gz" | cut -f1)"
+
+echo "[dump] crontabs..."
+crontab -l 2>/dev/null | tee "$STAGING/crontab-kimoto.txt" > /dev/null \
+  || echo "(no crontab for kimoto)" > "$STAGING/crontab-kimoto.txt"
+sudo crontab -l 2>/dev/null | tee "$STAGING/crontab-root.txt" > /dev/null \
+  || echo "(no crontab for root)" > "$STAGING/crontab-root.txt"
+
+echo "[dump] installed packages..."
+rpm -qa --queryformat "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" | sort > "$STAGING/rpm-qa.txt"
+dnf repolist > "$STAGING/dnf-repolist.txt" 2>/dev/null || true
+
+echo "[dump] nginx logs..."
+sudo cp -r /usr/local/nginx/logs/. "$STAGING/nginx-logs/" 2>/dev/null || true
+sudo chown -R kimoto:users "$STAGING/nginx-logs" 2>/dev/null || true
+
+echo "[dump] Done. $(du -sh "$STAGING" | cut -f1) in $STAGING"

--- a/bin/vps-backup-pull.sh
+++ b/bin/vps-backup-pull.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Pull a backup from the Sakura VPS to ~/Backups/vps/ on this Mac.
+# Run manually: vps-backup-pull.sh
+# Requires SSH key auth to tk2-237-28023.vs.sakura.ne.jp.
+set -euo pipefail
+
+VPS="kimoto@tk2-237-28023.vs.sakura.ne.jp"
+DEST="$HOME/Backups/vps"
+
+rsync_or_warn() {
+  rsync "$@" || {
+    rc=$?
+    { [ "$rc" -eq 23 ] || [ "$rc" -eq 10 ]; } \
+      && echo "[warn] rsync: some files skipped (exit $rc)" \
+      || exit "$rc"
+  }
+}
+
+echo "=== vps-backup-pull started at $(date '+%Y-%m-%d %H:%M:%S') ==="
+
+echo "--- [1/5] Running dump on VPS ---"
+ssh "$VPS" "bash ~/bin/vps-backup-dump.sh"
+
+mkdir -p "$DEST"
+
+echo "--- [2/7] Pulling backup-staging (MariaDB, systemd, cron.d, sshd) ---"
+rsync_or_warn -az --delete "$VPS:~/backup-staging/" "$DEST/staging/"
+
+echo "--- [3/7] Pulling /srv/kymt.me ---"
+rsync_or_warn -az --delete --rsync-path="sudo rsync" "$VPS:/srv/kymt.me/" "$DEST/srv/"
+
+echo "--- [4/7] Pulling ~/docs (e2e, plans) ---"
+rsync_or_warn -az --delete "$VPS:~/docs/" "$DEST/docs/"
+
+echo "--- [5/7] Pulling /usr/local/nginx/conf ---"
+rsync_or_warn -az --delete "$VPS:/usr/local/nginx/conf/" "$DEST/nginx-conf/"
+
+echo "--- [6/10] Pulling ~/.ssh ---"
+rsync_or_warn -az --delete "$VPS:~/.ssh/" "$DEST/ssh/"
+
+echo "--- [7/10] Pulling ~/projects ---"
+rsync_or_warn -az --delete "$VPS:~/projects/" "$DEST/projects/"
+
+echo "--- [8/10] Pulling ~/.gnupg ---"
+rsync_or_warn -az --delete "$VPS:~/.gnupg/" "$DEST/gnupg/"
+
+echo "--- [9/10] Pulling ~/.aws ---"
+rsync_or_warn -az --delete "$VPS:~/.aws/" "$DEST/aws/"
+
+echo "--- [10/19] Pulling ~/ (all home files, excl cache) ---"
+mkdir -p "$DEST/home-all"
+rsync_or_warn -az --delete \
+  --exclude='.cache/' \
+  --exclude='.zsh-evalcache/' \
+  "$VPS:~/" "$DEST/home-all/"
+
+echo "--- [11/13] Pulling /etc/hosts ---"
+rsync_or_warn -az "$VPS:/etc/hosts" "$DEST/staging/etc/"
+
+echo "--- [12/13] Pulling /usr/local/nginx/html ---"
+rsync_or_warn -az --delete --rsync-path="sudo rsync" "$VPS:/usr/local/nginx/html/" "$DEST/nginx-html/"
+
+echo "--- [13/19] Pulling ~/.claude ---"
+rsync_or_warn -az --delete "$VPS:~/.claude/" "$DEST/claude/"
+
+echo "--- [14/19] Pulling ~/.local/share/claude (session data) ---"
+rsync_or_warn -az --delete "$VPS:~/.local/share/claude/" "$DEST/local-share-claude/"
+
+echo "--- [15/19] Pulling /usr/local/mise/data (system Ruby) ---"
+rsync_or_warn -az --delete "$VPS:/usr/local/mise/data/" "$DEST/mise-system-data/"
+
+echo "--- [16/19] Pulling /usr/local/nginx/sbin (nginx+passenger binary) ---"
+rsync_or_warn -az --delete "$VPS:/usr/local/nginx/sbin/" "$DEST/nginx-sbin/"
+
+echo "--- [17/19] Pulling ~/.local/share/mise (user mise data, excl python) ---"
+rsync_or_warn -az --delete --exclude='installs/python/' "$VPS:~/.local/share/mise/" "$DEST/mise-user-data/"
+
+echo "--- [18/19] Pulling ~/.local/share/nvim (nvim plugins) ---"
+rsync_or_warn -az --delete "$VPS:~/.local/share/nvim/" "$DEST/nvim-data/"
+
+echo "--- [19/19] Pulling ~/build (nginx source & build logs) ---"
+rsync_or_warn -az --delete "$VPS:~/build/" "$DEST/build/"
+
+echo ""
+echo "=== Backup complete ==="
+du -sh "$DEST"/*/
+echo "Total: $(du -sh "$DEST" | cut -f1)"


### PR DESCRIPTION
## Summary

Expanded the VPS backup scripts to close gaps identified by a comprehensive audit: home dotdirs (including `.ethereum/keystore`), full `/etc/` tarball, crontabs, package manifests, and nginx logs were not previously captured. Also fixed root-owned file permission errors by using `--rsync-path="sudo rsync"`.

## Changes

- **dump.sh**: add `/etc/` full tarball, crontabs (kimoto + root), `rpm -qa` package list, `dnf repolist`, nginx access/error logs; add `--routines --events` to `mysqldump` and verify dump completeness with tail check; fix `sudo > file` shellcheck warnings by piping through `tee`
- **pull.sh**: replace `home-files` (direct files only, `--exclude='*/'`) with `home-all` (full `~/` mirror excluding `.cache/` and `.zsh-evalcache/`) — captures `.ethereum/keystore`, `.gem/`, `.bundle/`, and all other dotdirs; add `--rsync-path="sudo rsync"` to `srv/` and `nginx-html/` pulls so root-owned files (e.g. `wiki/maintenance/.htaccess`) are no longer silently skipped

## Verification

- Ran `vps-backup-pull.sh` end-to-end; completed without errors (only expected exit-10 warn from mise/python symlink loop, excluded via `--exclude='installs/python/'`)
- Confirmed `home-all/.ethereum/keystore` present in backup
- Confirmed `staging/letsencrypt/` contains `archive/`, `renewal/`, and `live/`
- Confirmed `staging/mariadb-all.sql.gz` tail ends with `-- Dump completed on …`
- Confirmed `staging/etc-all.tar.gz` (6.6M), `staging/crontab-*.txt`, `staging/rpm-qa.txt` all present
- Total backup size: 5.8G (up from 4.6G due to home-all replacing home-files)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none