### PR TITLE
chore(git): prune stale remotes on fetch, sort branches by recency

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,7 +13,6 @@
   pager = delta
   editor = nvim
   autoCRLF = false
-  syntax-theme = Solarized (dark)
 
 [commit]
   gpgsign = true
@@ -52,6 +51,12 @@
 
 [pull]
   ff = only
+
+[fetch]
+  prune = true
+
+[branch]
+  sort = -committerdate
 
 [url "git@github.com:"]
   pushinsteadof = "git://github.com/"


### PR DESCRIPTION
## Summary

Add `fetch.prune` and `branch.sort` to `.gitconfig`, and remove one dead config entry. Keeps `git branch -a` clean of merged remote refs automatically, and surfaces recently-touched branches at the top of branch listings.

## Changes

- `fetch.prune = true` — automatically delete stale remote-tracking refs on every fetch/pull, eliminating the need to run `git remote prune origin` by hand
- `branch.sort = -committerdate` — sort `git branch` output by most-recently-committed instead of alphabetically; most recent work shows first
- Remove `[core] syntax-theme` — delta reads this setting only from the `[delta]` section; the `[core]` entry was silently ignored dead config

## Verification

- `git config --list` confirms all three settings are applied correctly

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none