### PR TITLE
feat(keybindings): tmux pane nav, keybinding docs, Rectangle-friendly AeroSpace

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -3,10 +3,10 @@ config-version = 2
 
 # You can use it to add commands that run after AeroSpace startup.
 # Available commands : https://nikitabobko.github.io/AeroSpace/commands
-after-startup-command = []
+after-startup-command = ['workspace 1']
 
 # Start AeroSpace at login
-start-at-login = true
+start-at-login = false
 
 # Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
 enable-normalization-flatten-containers = true
@@ -138,16 +138,7 @@ automatically-unhide-macos-hidden-apps = false
     # See: https://nikitabobko.github.io/AeroSpace/commands#mode
     alt-shift-semicolon = 'mode service'
 
-[workspace-to-monitor-force-assignment]
-    1 = 'main'
-    2 = 'main'
-    3 = 'main'
-    4 = 'main'
-    5 = ['secondary', 'main']
-    6 = ['secondary', 'main']
-    7 = ['secondary', 'main']
-    8 = ['secondary', 'main']
-    9 = ['secondary', 'main']
+# No forced workspace-to-monitor assignment: Rectangle handles cross-monitor moves
 
 # 'service' binding mode declaration.
 # See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -27,6 +27,12 @@ bind-key -n M-8 select-window -t 8
 bind-key -n M-9 select-window -t 9
 bind-key -n M-t new-window
 
+# pane navigation (like vim hjkl)
+bind-key -n M-h select-pane -L
+bind-key -n M-j select-pane -D
+bind-key -n M-k select-pane -U
+bind-key -n M-l select-pane -R
+
 # pane move: m でmark → M で移動
 bind-key M join-pane -s .
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -1,0 +1,112 @@
+# Keybindings
+
+Hierarchical keybinding reference. Upper layers intercept keys first.
+
+Symbols: ⌘ = Command, ⌥ = Option/Alt, ⌃ = Control, ⇧ = Shift
+
+---
+
+## macOS (global)
+
+| Key | Action |
+|-----|--------|
+| ⌘+Tab | Switch apps |
+| ⌘+` | Switch windows within app |
+| ⌘+Space | Spotlight |
+| ⌘+H | Hide app |
+| ⌘+M | Minimize |
+| ⌘+Q | Quit app |
+| ⌘+W | Close window |
+| ⌃+Left / Right | Switch spaces |
+| ⌃+Up | Mission Control |
+| ⌃+Down | Application windows |
+| ⌘+⇧+3 | Screenshot (full) |
+| ⌘+⇧+4 | Screenshot (selection) |
+| ⌘+⇧+5 | Screenshot menu |
+
+---
+
+## AeroSpace (global, intercepts before apps)
+
+| Key | Action |
+|-----|--------|
+| ⌥+h/j/k/l | Focus window left / down / up / right |
+| ⌥+⇧+h/j/k/l | Move window left / down / up / right |
+| ⌥+1~5 | Switch to workspace 1~5 |
+| ⌥+⇧+1~5 | Move window to workspace 1~5 |
+| ⌥+Tab | Workspace back and forth |
+| ⌥+⇧+Tab | Move workspace to next monitor |
+| ⌥+/ | Layout: tiles (horizontal/vertical) |
+| ⌥+, | Layout: accordion (horizontal/vertical) |
+| ⌥+- | Resize -50 |
+| ⌥+= | Resize +50 |
+| ⌥+F | Fullscreen |
+| ⌥+0 | Reset layout (flatten workspace tree) |
+| ⌥+⇧+; | Enter service mode |
+
+---
+
+## Ghostty (intercepts before tmux)
+
+| Key | Action |
+|-----|--------|
+| F12 | Toggle quick terminal (global) |
+| ⌘+1~9 | → sends ESC+1~9 to tmux (window switching) |
+| ⌘+⇧+O | Toggle background opacity |
+| ¥ | Insert `\` (backslash) |
+
+`macos-option-as-alt = true` — ⌥ always sends ESC prefix (Meta key) to tmux.  
+⌥+0~5 are unbound in Ghostty, passed through to AeroSpace.
+
+---
+
+## tmux (prefix: C-t)
+
+### Windows (no prefix)
+
+| Key | Action |
+|-----|--------|
+| ⌘+1~9 | Switch to window 1~9 |
+| ⌘+T (M-t) | New window |
+
+### Panes (no prefix)
+
+| Key | Action |
+|-----|--------|
+| ⌥⌘+h/j/k/l | Select pane left / down / up / right |
+
+⌥⌘+hjkl works because Ghostty sends ESC+hjkl (M-hjkl) even with ⌘ held,
+while AeroSpace only intercepts plain ⌥+hjkl.
+
+### With prefix (C-t)
+
+| Key | Action |
+|-----|--------|
+| prefix + Right | Join pane to next window |
+| prefix + Left | Join pane to previous window |
+| prefix + m | Mark pane |
+| prefix + M | Move marked pane here (join-pane) |
+| prefix + Space | Cycle layout |
+
+### Copy mode (vi)
+
+| Key | Action |
+|-----|--------|
+| v | Begin selection |
+| y | Copy to clipboard and exit |
+| [ | Jump to previous prompt |
+| ] | Jump to next prompt |
+
+---
+
+## zsh (emacs mode)
+
+| Key | Action |
+|-----|--------|
+| ⌃+R | History search |
+| ⌃+A / E | Beginning / end of line |
+| ⌃+W | Delete word backward |
+| ⌃+U | Clear line |
+| ⌃+L | Clear screen |
+| ⌥+B / F | Move word backward / forward |
+| ⌥+D | Delete word forward |


### PR DESCRIPTION
## Summary

Add vim-style tmux pane navigation, document the full keybinding stack, and stop forcing AeroSpace workspace-to-monitor assignment so Rectangle can move windows across monitors freely.

## Changes

- tmux: add `M-hjkl` pane navigation (vim-style select-pane)
- aerospace: disable `start-at-login`, drop `workspace-to-monitor-force-assignment` so Rectangle handles cross-monitor moves, focus workspace 1 on startup
- add `KEYBINDINGS.md`: hierarchical keybinding reference across macOS, AeroSpace, Ghostty, tmux, and zsh layers

## Verification

- lefthook pre-commit / commit-msg hooks pass (editorconfig, config-syntax, conventional, gitleaks clean)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
