### PR TITLE
ci(lint): cover all tracked shell scripts and fix install_vscode.sh

### DIFF
--- a/bin/lint_shell.sh
+++ b/bin/lint_shell.sh
@@ -1,17 +1,34 @@
 #!/bin/bash
 
-# Static checks for shell scripts.
+# Static checks for shell scripts (bash -n syntax + shellcheck).
 # Single source of truth shared by CI (.github/workflows/ci.yml) and the
 # lefthook pre-commit hook (lefthook.yml), so the checks never diverge.
+# Covers every tracked *.sh script (bin/, vscode/, .claude/hooks/, …), not
+# just bin/. Pass files as arguments; with none, all tracked *.sh are checked.
 
-set -e
+set -euo pipefail
 
 BASE_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." || exit 1; pwd)
 cd "$BASE_DIR" || exit 1
 
+# Keep only files that still exist: a staged deletion can reach us as an arg,
+# and expanding an empty array under `set -u` aborts on bash 3.2 (macOS).
+files=()
+if [ "$#" -gt 0 ]; then
+    for f in "$@"; do
+        [ -f "$f" ] && files+=("$f")
+    done
+else
+    while IFS= read -r f; do
+        [ -f "$f" ] && files+=("$f")
+    done < <(git ls-files '*.sh')
+fi
+
+[ "${#files[@]}" -eq 0 ] && exit 0
+
 # Syntax check each script (bash -n only inspects its first file argument).
-for f in bin/*.sh; do
+for f in "${files[@]}"; do
     bash -n "$f"
 done
 
-shellcheck bin/*.sh
+shellcheck "${files[@]}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,8 +10,8 @@ pre-commit:
     protect-main:
       run: ./bin/protect_main.sh commit
     shell-lint:
-      glob: "bin/*.sh"
-      run: ./bin/lint_shell.sh
+      glob: "*.sh"
+      run: ./bin/lint_shell.sh {staged_files}
     unit-tests:
       glob:
         - "bin/*.sh"

--- a/vscode/install_vscode.sh
+++ b/vscode/install_vscode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 VSCODE_SETTING_DIR=~/Library/Application\ Support/Code/User
 
 rm "$VSCODE_SETTING_DIR/settings.json"
@@ -9,10 +9,10 @@ ln -s "$SCRIPT_DIR/settings.json" "${VSCODE_SETTING_DIR}/settings.json"
 rm "$VSCODE_SETTING_DIR/keybindings.json"
 ln -s "$SCRIPT_DIR/keybindings.json" "${VSCODE_SETTING_DIR}/keybindings.json"
 
-# install extention
-cat extensions | while read line
+# install extensions
+while read -r line
 do
- code --install-extension $line
-done
+    code --install-extension "$line"
+done < extensions
 
 code --list-extensions > extensions


### PR DESCRIPTION
## Summary

`lint_shell.sh` only ever checked `bin/*.sh`, so shell scripts elsewhere in the repo (`vscode/`, `.claude/hooks/`) were never syntax-checked or shellchecked. This broadens the lint to every tracked `*.sh` and fixes the warnings that had accumulated in the previously-unchecked `vscode/install_vscode.sh`.

## Changes

- `vscode/install_vscode.sh`: quote command substitutions and the loop variable, drop the useless `cat` in favor of a redirect, read with `-r`, and fix the `extention` typo (SC2046/SC2086/SC2002/SC2162). Behavior unchanged.
- `bin/lint_shell.sh`: discover targets via `git ls-files '*.sh'` (or explicit file args, matching the sibling `lint_*.sh` scripts) instead of hard-coding `bin/*.sh`. Filters non-existent paths and guards the empty case before any array expansion so it stays safe under bash 3.2's `set -u`.
- `lefthook.yml`: broaden the `shell-lint` glob from `bin/*.sh` to `*.sh` and pass `{staged_files}`.

## Verification

- `bash -n` + `shellcheck` pass for all 41 tracked `*.sh` scripts.
- Exercised `lint_shell.sh` with no args (full scan), explicit file args, and a non-existent path (exits 0).
- `./bin/run_tests.sh` — all 96 bats tests green.
- lefthook pre-commit ran `shell-lint` against staged files and `unit-tests`; both green, confirming the broadened glob and `{staged_files}` wiring.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none


---
_Generated by [Claude Code](https://claude.ai/code/session_012gvcBeJgiaUgHk8zQL9H71)_