### PR TITLE
feat(tmux): bind cmd+opt+arrow for window nav

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -33,6 +33,10 @@ bind-key -n M-j select-pane -D
 bind-key -n M-k select-pane -U
 bind-key -n M-l select-pane -R
 
+# command+option+←/→でwindow移動
+bind-key -n M-Left previous-window
+bind-key -n M-Right next-window
+
 # pane move: m でmark → M で移動
 bind-key M join-pane -s .
 

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -19,6 +19,9 @@ keybind = super+digit_6=text:\x1b6
 keybind = super+digit_7=text:\x1b7
 keybind = super+digit_8=text:\x1b8
 keybind = super+digit_9=text:\x1b9
+# command+option+←/→でtmux window移動 (デフォルトのgoto_splitはtmux常駐のため未使用)
+keybind = super+alt+arrow_left=text:\x1b[1;3D
+keybind = super+alt+arrow_right=text:\x1b[1;3C
 keybind = super+shift+o=toggle_background_opacity
 
 # Alt+数字はAeroSpaceのワークスペース切り替えに使うため素通しさせる


### PR DESCRIPTION
## Summary

Bind `command+option+←/→` to switch tmux windows, matching the existing chrome-like `command+1〜9` window-select behavior.

## Changes

- `config/ghostty/config`: rebind `super+alt+arrow_left/right` (default: `goto_split`, unused since Ghostty always runs a single tmux-attached split) to send the Alt+Left/Right escape sequence (`\x1b[1;3D` / `\x1b[1;3C`).
- `.tmux.conf`: bind `-n M-Left`/`M-Right` to `previous-window`/`next-window`.

## Verification

- Verified live: reloaded `~/.tmux.conf` via `tmux source-file`, pressed `command+option+←/→` in Ghostty, confirmed window switches correctly.
- Verified `\x1b[1;3D`/`\x1b[1;3C` parse to `M-Left`/`M-Right` by feeding the raw bytes into an isolated tmux server via a pty and confirming the bound commands fire.
- Confirmed no conflicting `M-Left`/`M-Right` bindings from installed plugins (tmux-pain-control, tmux-sensible, etc.).
- Rebased onto latest `main` to resolve a conflict in `.tmux.conf` with #79's "pane navigation (hjkl)" block (both insertions kept, no functional overlap).
- `gitleaks git --log-opts "main..HEAD"`: no leaks found.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
