### PR TITLE
refactor(vps): auto-number backup progress steps

### DIFF
--- a/bin/vps-backup-pull.sh
+++ b/bin/vps-backup-pull.sh
@@ -19,33 +19,33 @@ rsync_or_warn() {
 
 echo "=== vps-backup-pull started at $(date '+%Y-%m-%d %H:%M:%S') ==="
 
-echo "--- [1/5] Running dump on VPS ---"
+echo "--- [1/19] Running dump on VPS ---"
 ssh "$VPS" "bash ~/bin/vps-backup-dump.sh"
 
 mkdir -p "$DEST"
 
-echo "--- [2/7] Pulling backup-staging (MariaDB, systemd, cron.d, sshd) ---"
+echo "--- [2/19] Pulling backup-staging (MariaDB, systemd, cron.d, sshd) ---"
 rsync_or_warn -az --delete "$VPS:~/backup-staging/" "$DEST/staging/"
 
-echo "--- [3/7] Pulling /srv/kymt.me ---"
+echo "--- [3/19] Pulling /srv/kymt.me ---"
 rsync_or_warn -az --delete --rsync-path="sudo rsync" "$VPS:/srv/kymt.me/" "$DEST/srv/"
 
-echo "--- [4/7] Pulling ~/docs (e2e, plans) ---"
+echo "--- [4/19] Pulling ~/docs (e2e, plans) ---"
 rsync_or_warn -az --delete "$VPS:~/docs/" "$DEST/docs/"
 
-echo "--- [5/7] Pulling /usr/local/nginx/conf ---"
+echo "--- [5/19] Pulling /usr/local/nginx/conf ---"
 rsync_or_warn -az --delete "$VPS:/usr/local/nginx/conf/" "$DEST/nginx-conf/"
 
-echo "--- [6/10] Pulling ~/.ssh ---"
+echo "--- [6/19] Pulling ~/.ssh ---"
 rsync_or_warn -az --delete "$VPS:~/.ssh/" "$DEST/ssh/"
 
-echo "--- [7/10] Pulling ~/projects ---"
+echo "--- [7/19] Pulling ~/projects ---"
 rsync_or_warn -az --delete "$VPS:~/projects/" "$DEST/projects/"
 
-echo "--- [8/10] Pulling ~/.gnupg ---"
+echo "--- [8/19] Pulling ~/.gnupg ---"
 rsync_or_warn -az --delete "$VPS:~/.gnupg/" "$DEST/gnupg/"
 
-echo "--- [9/10] Pulling ~/.aws ---"
+echo "--- [9/19] Pulling ~/.aws ---"
 rsync_or_warn -az --delete "$VPS:~/.aws/" "$DEST/aws/"
 
 echo "--- [10/19] Pulling ~/ (all home files, excl cache) ---"
@@ -55,10 +55,10 @@ rsync_or_warn -az --delete \
   --exclude='.zsh-evalcache/' \
   "$VPS:~/" "$DEST/home-all/"
 
-echo "--- [11/13] Pulling /etc/hosts ---"
+echo "--- [11/19] Pulling /etc/hosts ---"
 rsync_or_warn -az "$VPS:/etc/hosts" "$DEST/staging/etc/"
 
-echo "--- [12/13] Pulling /usr/local/nginx/html ---"
+echo "--- [12/19] Pulling /usr/local/nginx/html ---"
 rsync_or_warn -az --delete --rsync-path="sudo rsync" "$VPS:/usr/local/nginx/html/" "$DEST/nginx-html/"
 
 echo "--- [13/19] Pulling ~/.claude ---"

--- a/bin/vps-backup-pull.sh
+++ b/bin/vps-backup-pull.sh
@@ -17,69 +17,78 @@ rsync_or_warn() {
   }
 }
 
+# Auto-numbered progress. TOTAL counts the step() call sites in this file, so
+# adding or removing a step needs no manual renumbering.
+STEP=0
+TOTAL="$(grep -c '^step ' "${BASH_SOURCE[0]}")"
+step() {
+  STEP=$((STEP + 1))
+  echo "--- [$STEP/$TOTAL] $1 ---"
+}
+
 echo "=== vps-backup-pull started at $(date '+%Y-%m-%d %H:%M:%S') ==="
 
-echo "--- [1/19] Running dump on VPS ---"
+step "Running dump on VPS"
 ssh "$VPS" "bash ~/bin/vps-backup-dump.sh"
 
 mkdir -p "$DEST"
 
-echo "--- [2/19] Pulling backup-staging (MariaDB, systemd, cron.d, sshd) ---"
+step "Pulling backup-staging (MariaDB, systemd, cron.d, sshd)"
 rsync_or_warn -az --delete "$VPS:~/backup-staging/" "$DEST/staging/"
 
-echo "--- [3/19] Pulling /srv/kymt.me ---"
+step "Pulling /srv/kymt.me"
 rsync_or_warn -az --delete --rsync-path="sudo rsync" "$VPS:/srv/kymt.me/" "$DEST/srv/"
 
-echo "--- [4/19] Pulling ~/docs (e2e, plans) ---"
+step "Pulling ~/docs (e2e, plans)"
 rsync_or_warn -az --delete "$VPS:~/docs/" "$DEST/docs/"
 
-echo "--- [5/19] Pulling /usr/local/nginx/conf ---"
+step "Pulling /usr/local/nginx/conf"
 rsync_or_warn -az --delete "$VPS:/usr/local/nginx/conf/" "$DEST/nginx-conf/"
 
-echo "--- [6/19] Pulling ~/.ssh ---"
+step "Pulling ~/.ssh"
 rsync_or_warn -az --delete "$VPS:~/.ssh/" "$DEST/ssh/"
 
-echo "--- [7/19] Pulling ~/projects ---"
+step "Pulling ~/projects"
 rsync_or_warn -az --delete "$VPS:~/projects/" "$DEST/projects/"
 
-echo "--- [8/19] Pulling ~/.gnupg ---"
+step "Pulling ~/.gnupg"
 rsync_or_warn -az --delete "$VPS:~/.gnupg/" "$DEST/gnupg/"
 
-echo "--- [9/19] Pulling ~/.aws ---"
+step "Pulling ~/.aws"
 rsync_or_warn -az --delete "$VPS:~/.aws/" "$DEST/aws/"
 
-echo "--- [10/19] Pulling ~/ (all home files, excl cache) ---"
+step "Pulling ~/ (all home files, excl cache)"
 mkdir -p "$DEST/home-all"
 rsync_or_warn -az --delete \
   --exclude='.cache/' \
   --exclude='.zsh-evalcache/' \
   "$VPS:~/" "$DEST/home-all/"
 
-echo "--- [11/19] Pulling /etc/hosts ---"
+step "Pulling /etc/hosts"
 rsync_or_warn -az "$VPS:/etc/hosts" "$DEST/staging/etc/"
 
-echo "--- [12/19] Pulling /usr/local/nginx/html ---"
+step "Pulling /usr/local/nginx/html"
 rsync_or_warn -az --delete --rsync-path="sudo rsync" "$VPS:/usr/local/nginx/html/" "$DEST/nginx-html/"
 
-echo "--- [13/19] Pulling ~/.claude ---"
+step "Pulling ~/.claude"
 rsync_or_warn -az --delete "$VPS:~/.claude/" "$DEST/claude/"
 
-echo "--- [14/19] Pulling ~/.local/share/claude (session data) ---"
+step "Pulling ~/.local/share/claude (session data)"
 rsync_or_warn -az --delete "$VPS:~/.local/share/claude/" "$DEST/local-share-claude/"
 
-echo "--- [15/19] Pulling /usr/local/mise/data (system Ruby) ---"
+step "Pulling /usr/local/mise/data (system Ruby)"
 rsync_or_warn -az --delete "$VPS:/usr/local/mise/data/" "$DEST/mise-system-data/"
 
-echo "--- [16/19] Pulling /usr/local/nginx/sbin (nginx+passenger binary) ---"
+step "Pulling /usr/local/nginx/sbin (nginx+passenger binary)"
 rsync_or_warn -az --delete "$VPS:/usr/local/nginx/sbin/" "$DEST/nginx-sbin/"
 
-echo "--- [17/19] Pulling ~/.local/share/mise (user mise data, excl python) ---"
+step "Pulling ~/.local/share/mise (user mise data, excl python)"
 rsync_or_warn -az --delete --exclude='installs/python/' "$VPS:~/.local/share/mise/" "$DEST/mise-user-data/"
 
-echo "--- [18/19] Pulling ~/.local/share/nvim (nvim plugins) ---"
+step "Pulling ~/.local/share/nvim (nvim plugins)"
 rsync_or_warn -az --delete "$VPS:~/.local/share/nvim/" "$DEST/nvim-data/"
 
-echo "--- [19/19] Pulling ~/build (nginx source & build logs) ---"
+step "Pulling ~/build (nginx source & build logs)"
 rsync_or_warn -az --delete "$VPS:~/build/" "$DEST/build/"
 
 echo ""


### PR DESCRIPTION
## Summary

`bin/vps-backup-pull.sh` used hardcoded `[N/M]` progress labels, which drifted out of sync (mismatched totals) and required renumbering every subsequent label whenever a step was added or removed. This removes the hardcoding: a `step()` helper auto-increments the counter and derives the total from the number of step call sites in the file.

## Changes

- Fix the immediately-visible symptom: normalize the hardcoded denominators to a consistent `[1/19]`…`[19/19]` sequence.
- Replace the hardcoded labels with a `step "message"` helper:
  - `STEP` counter auto-increments per call.
  - `TOTAL` is computed at runtime via `grep -c '^step ' "${BASH_SOURCE[0]}"`.
  - Adding/removing a step needs no manual renumbering. Output is byte-for-byte identical to the previous `[N/19]` labels.

## Verification

- `bash -n bin/vps-backup-pull.sh` — pass
- `./bin/lint_shell.sh` (shellcheck) — pass
- Simulated the `step()` sequence with stubbed `ssh`/`rsync`; output matches the prior `[1/19]`…`[19/19]` labels exactly, `TOTAL` resolves to 19
- lefthook pre-commit (protect-main, secret-files, editorconfig, shell-lint, gitleaks, 96 unit tests) — all pass

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)