### PR TITLE
fix(zsh): stop brew bundle check from blocking shell startup

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -413,8 +413,9 @@ fi
 #=====================
 # Remind at startup when a Brewfile bundle has packages that aren't installed
 # yet (after adding a formula, or on a freshly bootstrapped machine). Notify
-# only and throttled to once per 24h; see bin/brew_bundle_check.sh. Skipped in
-# CI via DOTFILES_NO_BREW_CHECK.
+# only: prints the cached result and refreshes it in a background job (at most
+# once per 24h), so startup never blocks on brew; see bin/brew_bundle_check.sh.
+# Skipped in CI via DOTFILES_NO_BREW_CHECK.
 if [[ -z "${DOTFILES_NO_BREW_CHECK:-}" ]]; then
   _dotfiles_dir="${${(%):-%x}:A:h}"
   [[ -x "$_dotfiles_dir/bin/brew_bundle_check.sh" ]] && "$_dotfiles_dir/bin/brew_bundle_check.sh"

--- a/bin/brew_bundle_check.sh
+++ b/bin/brew_bundle_check.sh
@@ -7,10 +7,12 @@
 # machine — so the tools you expect are actually present. Notify-only: it never
 # installs anything, it just prints the exact `brew bundle install` to run.
 #
-# `brew bundle check` is comparatively slow, so it runs at most once per 24h and
-# its result is cached; every other login just reads the cached result and is
-# effectively free. Same "cheap nag, throttled expensive part" trade-off as
-# dotfiles_sync_check.sh, so the "missing" warning can be one day stale.
+# `brew bundle check` is comparatively slow, so startup never waits for it: the
+# foreground only prints the cached result of the previous check, then a
+# detached background job refreshes the cache (at most once per 24h, or sooner
+# when a Brewfile or the Homebrew Cellar changed). The warning can therefore be
+# one shell stale — the same trade-off dotfiles_sync_check.sh makes for its
+# background `git fetch`.
 #
 # Skipped entirely when DOTFILES_NO_BREW_CHECK is set (used by CI so the load
 # test neither slows down nor prints reminder noise).
@@ -36,59 +38,85 @@ mkdir -p "$cache_dir" 2>/dev/null || true
 stamp="$cache_dir/last_brew_check"
 result="$cache_dir/brew_missing"
 
-# Re-run the (slow) check at most once per 24h; otherwise reuse the cached list.
-need_check=1
-if [ -f "$stamp" ] && [ -f "$result" ]; then
-    last=$(cat "$stamp" 2>/dev/null || echo 0)
-    case "$last" in
-        '' | *[!0-9]*) last=0 ;;
-    esac
-    if [ "$(( $(date +%s) - last ))" -lt 86400 ]; then
-        need_check=0
-    fi
+#---------------------------------------------------------------
+# foreground: print the cached result and get out of the way
+#---------------------------------------------------------------
+if [ -s "$result" ]; then
+    yellow=$'\033[33m'
+    cyan=$'\033[36m'
+    reset=$'\033[0m'
+
+    # One line per unsatisfied Brewfile, with a ready-to-run install command.
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        printf '%s[brew]%s %s has uninstalled packages -> %sbrew bundle install --file=%s/%s%s\n' \
+            "$yellow" "$reset" "$f" "$cyan" "$REPO_DIR" "$f" "$reset" >&2
+    done <"$result"
 fi
 
-# Invalidate cache if any Brewfile or the Homebrew Cellar changed since last check.
-if [ "$need_check" -eq 0 ]; then
-    cellar=$(brew --cellar 2>/dev/null) || cellar=""
-    for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"}; do
-        [ -e "$check_path" ] || continue
-        mtime=$(stat -c %Y "$check_path" 2>/dev/null || stat -f %m "$check_path" 2>/dev/null || echo 0)
-        if [ "$mtime" -gt "$last" ]; then
-            need_check=1
-            break
+#---------------------------------------------------------------
+# background: refresh the cache for the next shell
+#---------------------------------------------------------------
+# All fds are detached so neither the terminal nor the caller (zsh startup, or
+# bats' fd 3) ever waits on this job.
+(
+    # Re-run the (slow) check at most once per 24h.
+    need_check=1
+    if [ -f "$stamp" ] && [ -f "$result" ]; then
+        last=$(cat "$stamp" 2>/dev/null || echo 0)
+        case "$last" in
+            '' | *[!0-9]*) last=0 ;;
+        esac
+        if [ "$(( $(date +%s) - last ))" -lt 86400 ]; then
+            need_check=0
         fi
-    done
-fi
+    fi
 
-if [ "$need_check" -eq 1 ]; then
+    # Invalidate the cache if any Brewfile or the Homebrew Cellar changed since
+    # the last check.
+    if [ "$need_check" -eq 0 ]; then
+        cellar=$(brew --cellar 2>/dev/null) || cellar=""
+        for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"}; do
+            [ -e "$check_path" ] || continue
+            mtime=$(stat -c %Y "$check_path" 2>/dev/null || stat -f %m "$check_path" 2>/dev/null || echo 0)
+            if [ "$mtime" -gt "$last" ]; then
+                need_check=1
+                break
+            fi
+        done
+    fi
+
+    [ "$need_check" -eq 1 ] || exit 0
+
+    # Single-runner lock: a burst of new shells (e.g. tmux restoring panes)
+    # must not stampede N parallel `brew bundle check` runs. A leftover lock
+    # from a crashed run is stolen after 10 minutes.
+    lock="$cache_dir/brew_check.lock"
+    if ! mkdir "$lock" 2>/dev/null; then
+        lock_mtime=$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null || echo 0)
+        [ "$(( $(date +%s) - lock_mtime ))" -gt 600 ] || exit 0
+        rmdir "$lock" 2>/dev/null || true
+        mkdir "$lock" 2>/dev/null || exit 0
+    fi
+    trap 'rmdir "$lock" 2>/dev/null' EXIT
+
     missing=()
     for f in "${files[@]}"; do
         [ -f "$REPO_DIR/$f" ] || continue
         brew bundle check --file="$REPO_DIR/$f" >/dev/null 2>&1 || missing+=("$f")
     done
+
     # Persist the unsatisfied Brewfiles (one per line) + a stamp so later logins
-    # are free. Written even when empty, so "all satisfied" is also cached.
+    # are free. Written even when empty, so "all satisfied" is also cached, and
+    # replaced atomically so a shell reading mid-write never sees a torn file.
+    tmp="$result.tmp.$$"
     if [ "${#missing[@]}" -gt 0 ]; then
-        printf '%s\n' "${missing[@]}" >"$result" 2>/dev/null || true
+        printf '%s\n' "${missing[@]}" >"$tmp" 2>/dev/null || exit 0
     else
-        : >"$result" 2>/dev/null || true
+        : >"$tmp" 2>/dev/null || exit 0
     fi
+    mv -f "$tmp" "$result" 2>/dev/null || rm -f "$tmp" 2>/dev/null
     date +%s >"$stamp" 2>/dev/null || true
-fi
-
-# Nothing unsatisfied (empty or absent cache) -> stay silent.
-[ -s "$result" ] || exit 0
-
-yellow=$'\033[33m'
-cyan=$'\033[36m'
-reset=$'\033[0m'
-
-# One line per unsatisfied Brewfile, with a ready-to-run install command.
-while IFS= read -r f; do
-    [ -n "$f" ] || continue
-    printf '%s[brew]%s %s has uninstalled packages -> %sbrew bundle install --file=%s/%s%s\n' \
-        "$yellow" "$reset" "$f" "$cyan" "$REPO_DIR" "$f" "$reset" >&2
-done <"$result"
+) >/dev/null 2>&1 3>&- </dev/null &
 
 exit 0

--- a/test/brew_bundle_check.bats
+++ b/test/brew_bundle_check.bats
@@ -3,17 +3,22 @@
 # Behavioural tests for bin/brew_bundle_check.sh, the shell-startup reminder that
 # nags when a Brewfile bundle has uninstalled packages.
 #
-# The script shells out to `brew bundle check`, so each test runs a *copy* of it
-# inside a throwaway repo with Brewfiles present and a stub `brew` on PATH whose
-# exit code is scripted via BREW_CHECK_RC ("0" = satisfied, anything else =
-# missing). XDG_CACHE_HOME is redirected into the temp dir so the 24h throttle
-# stamp and the cached result file can be inspected and pre-seeded. Warnings go
-# to stderr, which bats folds into $output.
+# The script only prints the cached result of the *previous* check and refreshes
+# the cache in a detached background job, so most tests assert in two steps: run
+# once, wait_for the background refresh, then run again to observe the nag.
+#
+# Each test runs a *copy* of the script inside a throwaway repo with Brewfiles
+# present and a stub `brew` on PATH whose exit code is scripted via
+# BREW_CHECK_RC ("0" = satisfied, anything else = missing). XDG_CACHE_HOME is
+# redirected into the temp dir so the 24h throttle stamp and the cached result
+# file can be inspected and pre-seeded. Warnings go to stderr, which bats folds
+# into $output.
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   TMP="$(mktemp -d)"
   export XDG_CACHE_HOME="$TMP/cache"
+  CACHE="$XDG_CACHE_HOME/dotfiles"
 
   REPO="$TMP/repo"
   mkdir -p "$REPO/bin"
@@ -43,6 +48,17 @@ teardown() {
   rm -rf "$TMP"
 }
 
+# Poll until the condition holds (~5s timeout) — the detached background
+# refresh leaves no process handle to wait on.
+wait_for() {
+  for _ in $(seq 1 50); do
+    eval "$1" && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for: $1" >&2
+  return 1
+}
+
 @test "DOTFILES_NO_BREW_CHECK short-circuits with no output" {
   BREW_CHECK_RC=1 DOTFILES_NO_BREW_CHECK=1 run "$SCRIPT"
   [ "$status" -eq 0 ]
@@ -56,16 +72,30 @@ teardown() {
   [ -z "$output" ]
 }
 
+@test "first run is silent and populates the cache in the background" {
+  BREW_CHECK_RC=1 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  wait_for '[ -s "$CACHE/brew_missing" ]'
+  [ -f "$CACHE/last_brew_check" ]
+}
+
 @test "silent when all bundles are satisfied" {
   BREW_CHECK_RC=0 run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
   # The result cache exists but is empty.
-  [ -f "$XDG_CACHE_HOME/dotfiles/brew_missing" ]
-  [ ! -s "$XDG_CACHE_HOME/dotfiles/brew_missing" ]
+  wait_for '[ -f "$CACHE/brew_missing" ]'
+  [ ! -s "$CACHE/brew_missing" ]
+  # Warm cache: still silent.
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 
-@test "warns and names the unsatisfied bundle when packages are missing" {
+@test "warns from the cached result and names the unsatisfied bundle" {
+  BREW_CHECK_RC=1 run "$SCRIPT"
+  wait_for '[ -s "$CACHE/brew_missing" ]'
   BREW_CHECK_RC=1 run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"[brew]"* ]]
@@ -73,22 +103,46 @@ teardown() {
   [[ "$output" == *"brew bundle install --file="* ]]
 }
 
-@test "caches the result and a stamp, then reuses it without re-checking" {
+@test "reuses the cached nag within 24h without re-checking" {
   BREW_CHECK_RC=1 run "$SCRIPT"
-  [ -f "$XDG_CACHE_HOME/dotfiles/last_brew_check" ]
-  [ -s "$XDG_CACHE_HOME/dotfiles/brew_missing" ]
-
+  wait_for '[ -s "$CACHE/brew_missing" ]'
   # Within 24h the stub flipping to "satisfied" must NOT change the cached nag.
   BREW_CHECK_RC=0 run "$SCRIPT"
   [[ "$output" == *"Brewfile.basic"* ]]
+  # Give a rogue background re-check time to clear the cache; it must not have.
+  sleep 1
+  [ -s "$CACHE/brew_missing" ]
 }
 
-@test "re-checks once the throttle stamp is older than 24h" {
-  BREW_CHECK_RC=1 run "$SCRIPT"          # seed a "missing" cache
-  [[ "$output" == *"Brewfile.basic"* ]]
+@test "re-checks in the background once the stamp is older than 24h" {
+  BREW_CHECK_RC=1 run "$SCRIPT" # seed a "missing" cache
+  wait_for '[ -s "$CACHE/brew_missing" ]'
 
-  # Backdate the stamp beyond 24h; a now-satisfied check must clear the nag.
-  echo "$(( $(date +%s) - 90000 ))" >"$XDG_CACHE_HOME/dotfiles/last_brew_check"
+  # Backdate the stamp beyond 24h; a now-satisfied check clears the nag, but
+  # only for the *next* shell — this session still shows the stale nag.
+  echo "$(( $(date +%s) - 90000 ))" >"$CACHE/last_brew_check"
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  [[ "$output" == *"Brewfile.basic"* ]]
+  wait_for '[ ! -s "$CACHE/brew_missing" ]'
   BREW_CHECK_RC=0 run "$SCRIPT"
   [ -z "$output" ]
+}
+
+@test "startup does not block on a slow brew bundle check" {
+  # Stub sleeps 3s per bundle check; the foreground script must return before
+  # even a single check could have finished.
+  cat >"$STUB/brew" <<'STUBEOF'
+#!/bin/bash
+if [ "$1" = "bundle" ] && [ "$2" = "check" ]; then
+  sleep 3
+  exit 1
+fi
+exit 0
+STUBEOF
+  chmod +x "$STUB/brew"
+
+  start=$(date +%s)
+  "$SCRIPT" >/dev/null 2>&1
+  elapsed=$(( $(date +%s) - start ))
+  [ "$elapsed" -lt 3 ]
 }


### PR DESCRIPTION
## Summary

Shell startup occasionally stalled for several seconds because the Brewfile drift reminder ran `brew bundle check` in the foreground whenever its 24h stamp expired **or** the Homebrew Cellar mtime changed (i.e. the first shell of the day, and every shell right after a `brew install`/`upgrade`/autoupdate). Make the check fully asynchronous so startup never waits on brew.

## Changes

- `bin/brew_bundle_check.sh`: the foreground now only prints the cached result of the previous check; the throttle decision and the slow `brew bundle check` runs (3 Brewfiles, one Ruby brew launch each) moved into a detached background job — same pattern as `dotfiles_sync_check.sh`'s background `git fetch`, with the same "nag can be one shell stale" trade-off.
- Added a `mkdir`-based single-runner lock (stolen after 10 min if left by a crashed run) so a burst of new shells (e.g. tmux restoring panes) doesn't stampede parallel checks, and the result file is now replaced atomically so a concurrent shell never reads a torn cache.
- `test/brew_bundle_check.bats`: rewritten for the async contract (run → wait for the background refresh → run again), plus a new test pinning the non-blocking behaviour with a deliberately slow (3s) brew stub.
- `.zshrc`: updated the reminder's comment block to describe the new behaviour.

## Verification

- TDD red→green: the new bats tests were run against the old synchronous script first — the 3 tests encoding the async behaviour failed as expected — then passed after the rewrite.
- `bats test/brew_bundle_check.bats`: 8/8 pass.
- `./bin/run_tests.sh`: full suite 108/108 pass.
- `./bin/lint_shell.sh`, `./bin/lint_editorconfig.sh`: clean.
- `./bin/ci_zsh_loading_test.sh` fails locally only because `starship` isn't installed in this container (environment limitation; the script under test is skipped there via `DOTFILES_NO_BREW_CHECK` anyway) — covered by CI.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkyTYiu7VHn9rsiD9h9HsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkyTYiu7VHn9rsiD9h9HsG)_