### PR TITLE
fix(zsh): cut per-shell and per-prompt startup costs

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -49,6 +49,11 @@ if [[ ! -e "$_zcompdump" || $#_zcompdump_stale -gt 0 ]]; then
 else
   compinit -C -d "$_zcompdump"
 fi
+# Compile the dump to wordcode; zsh sources the .zwc automatically when it is
+# at least as new as the dump. Recompile only right after a dump rebuild.
+if [[ -s "$_zcompdump" && ( ! -s "$_zcompdump.zwc" || "$_zcompdump" -nt "$_zcompdump.zwc" ) ]]; then
+  zcompile "$_zcompdump"
+fi
 unset _zcompdump _zcompdump_stale
 
 #=====================
@@ -74,10 +79,9 @@ sudo_path=(
 #=====================
 # package managers / plugins
 #=====================
-if builtin command -v brew >/dev/null; then
-  eval "$(brew shellenv)"
-fi
-
+# brew shellenv is not eval'd here: its output is static per machine, so it is
+# cached via the brew-shellenv _evalcache inline in config/sheldon/plugins.toml.
+# The path=() block above already puts brew itself on PATH.
 if builtin command -v sheldon >/dev/null; then
   eval "$(sheldon source)"
 fi

--- a/.zshrc
+++ b/.zshrc
@@ -148,7 +148,7 @@ export CLICOLOR=1
 export XDG_CONFIG_HOME="$HOME/.config"
 # LS_COLORS is exported during `sheldon source` via _evalcache — see the
 # vivid-ls-colors inline plugin in config/sheldon/plugins.toml.
-export GPG_TTY=$(tty)
+export GPG_TTY=$TTY # zsh sets $TTY itself; saves a tty(1) fork per shell
 # carapace: fall back to zsh's native completions for commands it has no spec for
 export CARAPACE_BRIDGES='zsh,bash'
 
@@ -346,10 +346,20 @@ chpwd() {
   ll
 }
 
-# Keep the tmux window name in sync with the current directory.
+# Keep the tmux window name in sync with the current directory. Renames only
+# when the name actually changed, so the common case (precmd on every prompt)
+# forks nothing; the trade-off is that an external rename sticks until the
+# next cd.
 update_tmux_window () {
   [[ -n "$TMUX" ]] || return
-  tmux rename-window "$(basename "$PWD")"
+  # '.' and ':' are target separators that tmux (>= 3.7) rejects in window
+  # names ("invalid window name"), so map them to '_'.
+  local name="${${PWD:t}//[.:]/_}"
+  [[ "$name" == "${_tmux_window_name:-}" ]] && return
+  # Cache only after a successful rename, so a transient failure (tmux briefly
+  # off PATH mid-hook, server hiccup) is retried at the next prompt instead of
+  # silently sticking the wrong name forever.
+  tmux rename-window "$name" && _tmux_window_name="$name"
 }
 add-zsh-hook chpwd update_tmux_window
 add-zsh-hook precmd update_tmux_window

--- a/bin/ci_tmux_interactive_test.sh
+++ b/bin/ci_tmux_interactive_test.sh
@@ -35,6 +35,12 @@ trap cleanup EXIT
 tmux -L "$SOCK" new-session -d -x 200 -y 50 "$(zsh_pane_cmd)" ||
   die "failed to start tmux session"
 
+# Isolate the window-rename assertion (step 4) from tmux itself: with the
+# repo's .tmux.conf loaded, automatic-rename would follow pane_current_path
+# and could rename the window even if the zsh hook under test never ran.
+WIN_ID="$(tmux -L "$SOCK" display-message -p '#{window_id}')"
+tmux -L "$SOCK" set-option -w -t "$WIN_ID" automatic-rename off
+
 # 1) The interactive shell is live and rendering. Typing a command and seeing
 #    its *computed* output ($((6 * 7)) -> 42) on screen proves the full
 #    keystroke -> eval -> render path through a genuine terminal.
@@ -64,5 +70,44 @@ tmux -L "$SOCK" send-keys Up
 wait_for_pane "$SOCK" 'echo __E2E_HIST_MARK__'
 tmux -L "$SOCK" send-keys C-c
 echo "== zle Up-arrow recalled previous command =="
+
+# 4) update_tmux_window: after a cd, the chpwd hook must rename the tmux window
+#    to the directory tail. `builtin cd` bypasses the interactive cd->z alias so
+#    the assertion does not depend on zoxide being installed. mktemp's basename
+#    contains a '.' on purpose: tmux >= 3.7 rejects '.'/':' in window names
+#    (target separators), so the hook must sanitize them — pin that here.
+e2e_dir="$(mktemp -d)"
+e2e_base="$(basename "$e2e_dir")"
+e2e_name="$(printf '%s' "$e2e_base" | tr '.:' '__')"
+tmux -L "$SOCK" send-keys "builtin cd '$e2e_dir'" Enter
+i=0
+while [ "$i" -lt 50 ]; do
+  [ "$(tmux -L "$SOCK" display-message -p '#W' 2>/dev/null)" = "$e2e_name" ] && break
+  i=$((i + 1)); sleep 0.1
+done
+window_name="$(tmux -L "$SOCK" display-message -p '#W')"
+rmdir "$e2e_dir" 2>/dev/null || true
+if [ "$window_name" != "$e2e_name" ]; then
+  # Dump enough state to diagnose from the CI log alone: what's on screen
+  # (command-not-found noise, plugin errors), the window list, whether a
+  # manual rename disabled automatic-rename, and the hook state in the pane.
+  {
+    echo "---- diagnostics: windows ----"
+    tmux -L "$SOCK" list-windows -a \
+      -F '#{window_id} name=#{window_name} active=#{window_active} panes=#{window_panes} path=#{pane_current_path}'
+    echo "---- diagnostics: automatic-rename ----"
+    tmux -L "$SOCK" show-options -w automatic-rename || true
+    echo "---- diagnostics: pane hook state ----"
+    # shellcheck disable=SC2016  # single-quoted on purpose: the pane's zsh
+    # must expand these, not this shell.
+    tmux -L "$SOCK" send-keys \
+      'print "TMUX=$TMUX cache=${_tmux_window_name:-}"; whence -w update_tmux_window; print -l $chpwd_functions' Enter
+    sleep 1
+    echo "---- diagnostics: pane contents ----"
+    tmux -L "$SOCK" capture-pane -p
+  } >&2 || true
+  die "tmux window was not renamed to $e2e_name (got: $window_name)"
+fi
+echo "== tmux window renamed to the cd target ($e2e_name) =="
 
 echo "PASS"

--- a/bin/ci_zsh_loading_test.sh
+++ b/bin/ci_zsh_loading_test.sh
@@ -110,6 +110,8 @@ alias reload
 print "EDITOR=$EDITOR"
 print "VISUAL=$VISUAL"
 print "PAGER=$PAGER"
+print "HOMEBREW_PREFIX=${HOMEBREW_PREFIX:-unset}"
+print "ZCOMPDUMP_ZWC=$([[ -s ${ZDOTDIR:-$HOME}/.zcompdump.zwc ]] && echo yes || echo no)"
 for o in autocd autopushd share_history interactivecomments noclobber; do
   [[ -o $o ]] && print "OPT_ON:$o"
 done
@@ -133,6 +135,15 @@ require_grep "reload is not aliased to exec zsh" "$env_out" "reload=.*exec zsh"
 require_grep "EDITOR is not nvim"   "$env_out" "EDITOR=nvim"
 require_grep "VISUAL is not nvim"   "$env_out" "VISUAL=nvim"
 require_grep "PAGER does not use less" "$env_out" "PAGER=less"
+
+# brew shellenv: exported via the _evalcache inline in sheldon's plugins.toml,
+# not a direct eval in .zshrc. Gated on brew so brew-less boxes still pass.
+if command -v brew >/dev/null 2>&1; then
+  require_grep "HOMEBREW_PREFIX not exported (brew-shellenv evalcache inline)" "$env_out" "HOMEBREW_PREFIX=/"
+fi
+
+# compinit dump is compiled to wordcode so later startups parse it faster.
+require_grep ".zcompdump.zwc missing (zcompile after compinit)" "$env_out" "ZCOMPDUMP_ZWC=yes"
 
 # shell options (setopt)
 for opt in autocd autopushd share_history interactivecomments noclobber; do

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -39,6 +39,13 @@ post = "test -e ~/.cache/fsh/current_theme.zsh || { command -v fast-theme >/dev/
 #================
 # eval cache
 #================
+# Homebrew env (HOMEBREW_PREFIX, MANPATH, ...). The output is static per
+# machine, so cache it instead of launching `brew` on every shell. Finding
+# brew itself doesn't depend on this: .zshrc's path=() block already puts the
+# Homebrew bin dirs on PATH.
+[plugins.brew-shellenv]
+inline = 'if (( $+commands[brew] )); then _evalcache brew shellenv; fi'
+
 [plugins.starship]
 inline = '_evalcache starship init zsh'
 

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -58,8 +58,12 @@ inline = '_evalcache mise activate zsh'
 [plugins.direnv]
 inline = '_evalcache direnv hook zsh'
 
+# kubectl's completion script is big enough that even the cached copy takes
+# time to parse every startup: defer the parse past the first prompt. Guarded
+# on kubectl so machines without it (kubectl ships in Brewfile.common, not
+# basic) skip it silently.
 [plugins.kubectl-completion]
-inline = '_evalcache kubectl completion zsh'
+inline = 'if (( $+commands[kubectl] )); then zsh-defer _evalcache kubectl completion zsh; fi'
 
 # LS_COLORS palette. vivid prints a raw value (not shell code), so
 # bin/vivid_ls_colors.sh (on PATH via ~/bin) wraps it in an export statement.


### PR DESCRIPTION
## Summary

Follow-up to #84: that PR removed the occasional multi-second stall; this one shaves the recurring costs — per-shell (a live `brew` launch, compinit dump re-parse, a `tty` fork, kubectl completion parse) and per-prompt (tmux window rename forks). It also fixes a latent tmux ≥ 3.7 bug the new e2e coverage uncovered. Two commits, same theme.

## Changes

Commit 1 — cache brew shellenv and compile the compinit dump:

- `config/sheldon/plugins.toml`: new `brew-shellenv` inline that runs `_evalcache brew shellenv` (guarded on brew being installed), placed with the other eval caches (starship, zoxide, …). The output is static per machine, so after the first shell it's a cached file source instead of a brew launch.
- `.zshrc`: dropped the direct `eval "$(brew shellenv)"` (the `path=()` block already puts the Homebrew bin dirs on PATH, so finding brew/sheldon never depended on it), and added a `zcompile` of `.zcompdump` right after compinit — recompiled only when the dump itself was rebuilt; zsh picks up the `.zwc` automatically.
- `bin/ci_zsh_loading_test.sh`: the extended probe now asserts `HOMEBREW_PREFIX` is exported in an interactive shell (gated on brew, active in CI via linuxbrew) and that `.zcompdump.zwc` exists after a load.

Commit 2 — trim per-shell and per-prompt process spawns:

- `.zshrc`: `GPG_TTY` now uses zsh's own `$TTY` instead of forking `tty(1)` every shell.
- `.zshrc`: `update_tmux_window` ran `basename` + `tmux rename-window` on every prompt via precmd. It now computes the name with `${PWD:t}` and skips the rename when unchanged, so the steady state forks nothing (trade-off: an external rename sticks until the next cd). The cache is updated only after a *successful* rename, so a transient failure is retried at the next prompt instead of sticking the wrong name forever.
- `.zshrc`: **tmux ≥ 3.7 fix** — `rename-window` now rejects names containing `.`/`:` (target separators) with `invalid window name`, so any directory like `example.com` or `.config` silently broke the rename (and the pre-existing code would have spammed that error every prompt). The hook now maps those characters to `_`.
- `config/sheldon/plugins.toml`: kubectl completion is deferred past the first prompt with `zsh-defer` and guarded on kubectl being installed (it ships in `Brewfile.common`, not `basic`, so CI/fresh boxes skip it). carapace stays eager on purpose: tiny init, needed for the first Tab, and the CI compdef assertion relies on it.
- `bin/ci_tmux_interactive_test.sh`: new e2e step asserting a `cd` renames the tmux window to the (sanitized) directory tail — the mktemp dir keeps its `.` on purpose to pin the tmux 3.7 rejection. Uses `builtin cd` so it doesn't depend on zoxide, forces `automatic-rename off` first so tmux's own automatic-rename (from the repo `.tmux.conf`) can't mask a dead hook, and dumps diagnostics (window list, automatic-rename state, in-pane hook/cache state, pane contents) on failure.

## Verification

- TDD red→green for every new assertion:
  - zcompile: probe showed `ZCOMPDUMP_ZWC=no` before (red), `yes` after, including on a subsequent `compinit -C` load.
  - brew shellenv: with a stub `brew` and no working inline chain, the `HOMEBREW_PREFIX=/` assertion fails as intended (red); the full sheldon + evalcache + linuxbrew green path runs in CI.
  - tmux rename: red-green locally against real tmux 3.4 + zsh 5.9 with the repo's `.tmux.conf` installed as `~/.tmux.conf` (the CI layout); disabling the hook reproduces the CI failure signature, and the dot-sanitizing assertion is red on the unsanitized hook, green after.
- The first two CI runs of this branch failed on the new e2e step; the failure diagnostics identified tmux 3.7's `invalid window name: tmp.XXXX` as the root cause (visible in the run 28566902818 log), which is fixed by the sanitization above.
- `GPG_TTY` probed under a pty: resolves to `/dev/pts/0` via `$TTY`.
- `./bin/run_tests.sh`: 108/108 pass; `lint_shell` / `lint_config` / `lint_editorconfig` clean; lefthook pre-commit/pre-push hooks green.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Follow-up to #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkyTYiu7VHn9rsiD9h9HsG