### PR TITLE
feat(tmux): color pane/window when Claude Code waits for input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
       - name: e2e for the status bar and dynamic window/pane formats
         run: ./bin/ci_tmux_status_test.sh
 
+      - name: e2e for the Claude Code tmux state indicator (hook script + formats)
+        run: ./bin/ci_claude_tmux_indicator_test.sh
+
       - name: Starship prompt e2e (render in a real terminal, assert segments)
         run: ./bin/ci_starship_test.sh
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -98,8 +98,12 @@ set -g status-left-length 50
 set -g status-right-length 100
 set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #{session_name} #[fg=#268bd2,bg=#073642,nobold] "
 set -g status-right "#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
-setw -g window-status-format "#[fg=#{?window_bell_flag,#dc322f,#586e75},bg=#073642] #I:#W "
-setw -g window-status-current-format "#[fg=#073642,bg=#2aa198]#[fg=#002b36,bg=#2aa198,bold] #I:#W #[fg=#2aa198,bg=#073642]"
+# @claude_color is a window user option set by bin/claude_tmux_indicator.sh
+# (Claude Code hooks): red #dc322f = Claude waits for input/permission, yellow
+# #b58900 = finished. When set it overrides the window entry's color and
+# appends a ✳ marker; when unset these formats render exactly as before.
+setw -g window-status-format "#[fg=#{?#{@claude_color},#{@claude_color},#{?window_bell_flag,#dc322f,#586e75}},bg=#073642]#{?#{@claude_color},#[bold],} #I:#W#{?#{@claude_color}, ✳,} "
+setw -g window-status-current-format "#[fg=#073642,bg=#{?#{@claude_color},#{@claude_color},#2aa198}]#[fg=#002b36,bg=#{?#{@claude_color},#{@claude_color},#2aa198},bold] #I:#W#{?#{@claude_color}, ✳,} #[fg=#{?#{@claude_color},#{@claude_color},#2aa198},bg=#073642]"
 setw -g window-status-separator ""
 
 # '~/.tmux/plugins/tpm/tpm' returned 127 (on macOS, w/ tmux installed using brew)

--- a/bin/ci_claude_tmux_indicator_test.sh
+++ b/bin/ci_claude_tmux_indicator_test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# End-to-end test for the Claude Code tmux state indicator
+# (bin/claude_tmux_indicator.sh + the @claude_color conditionals in
+# .tmux.conf). Runs the real hook script against a real tmux server, then
+# asserts both layers: the options the script sets (window @claude_color, the
+# per-pane border overrides) and how the status-line formats render them —
+# expanded with `display-message -p`, exactly as tmux evaluates them when
+# drawing. Covers: waiting (red), done (yellow), red-beats-yellow priority
+# across panes in one window, clear (back to defaults), and the outside-tmux
+# no-op.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+. "$DIR/tmux_e2e_helpers.sh"
+
+need tmux
+echo "== $(tmux -V) =="
+
+# The ✳ marker is multibyte; under a non-UTF-8 locale (bare CI shells) tmux
+# renders it as '_' and the glyph assertions below would miss it.
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+CONF="$(tmux_conf_path)"
+echo "== conf under test: $CONF =="
+
+RED="#dc322f"
+YELLOW="#b58900"
+
+SOCK="ci_claude_ind_$$"
+SESS="INDCHECK"
+cleanup() { tmux -L "$SOCK" kill-server 2>/dev/null || true; }
+trap cleanup EXIT
+
+tmux -L "$SOCK" -f "$CONF" new-session -d -s "$SESS" -x 200 -y 50 || die "failed to start tmux"
+
+SOCK_PATH="$(tmux -L "$SOCK" display-message -p '#{socket_path}')"
+PANE1="$(tmux -L "$SOCK" display-message -p '#{pane_id}')"
+
+# Run the hook script the way Claude Code does: as a plain child process that
+# only knows it is inside tmux via $TMUX / $TMUX_PANE.
+ind() { TMUX="$SOCK_PATH,0,0" TMUX_PANE="$2" "$DIR/claude_tmux_indicator.sh" "$1"; }
+
+opt() { tmux -L "$SOCK" show-options -gqv "$1"; }
+win_color() { tmux -L "$SOCK" show-options -wqv -t "$PANE1" @claude_color; }
+pane_border() { tmux -L "$SOCK" show-options -pqv -t "$1" pane-border-style; }
+expand() { tmux -L "$SOCK" display-message -p "$1" 2>/dev/null | tr -d '\000'; }
+
+# 1) waiting -> red window option, red pane border, red + marker in both
+#    window-status formats.
+ind waiting "$PANE1"
+[ "$(win_color)" = "$RED" ] || die "waiting: window @claude_color expected $RED, got '$(win_color)'"
+pane_border "$PANE1" | grep -qF "$RED" || die "waiting: pane-border-style not overridden to $RED"
+expand "$(opt window-status-format)" | grep -qF "$RED" \
+  || die "waiting: window-status-format did not render $RED"
+expand "$(opt window-status-current-format)" | grep -qF "$RED" \
+  || die "waiting: window-status-current-format did not render $RED"
+expand "$(opt window-status-current-format)" | grep -qF "✳" \
+  || die "waiting: window-status-current-format did not render the ✳ marker"
+echo "== waiting colors the pane border and window entry red =="
+
+# 2) done -> same pane flips to yellow.
+ind 'done' "$PANE1"
+[ "$(win_color)" = "$YELLOW" ] || die "done: window @claude_color expected $YELLOW, got '$(win_color)'"
+pane_border "$PANE1" | grep -qF "$YELLOW" || die "done: pane-border-style not overridden to $YELLOW"
+echo "== done colors it yellow =="
+
+# 3) two panes in one window: a waiting (red) pane outranks a done (yellow)
+#    one; clearing the red pane falls back to yellow, not to default.
+tmux -L "$SOCK" split-window -d -t "$SESS"
+PANE2="$(tmux -L "$SOCK" list-panes -t "$SESS" -F '#{pane_id}' | grep -v "^$PANE1\$" | head -n1)"
+ind waiting "$PANE2"
+[ "$(win_color)" = "$RED" ] || die "priority: red pane should win over yellow, got '$(win_color)'"
+ind clear "$PANE2"
+[ "$(win_color)" = "$YELLOW" ] || die "priority: clearing the red pane should fall back to yellow"
+[ -z "$(pane_border "$PANE2")" ] || die "clear: pane 2 border override should be gone"
+echo "== red beats yellow across panes; clear recomputes the window color =="
+
+# 4) clear on the last flagged pane -> option unset, border override gone,
+#    formats back to the defaults (inactive gray, no marker).
+ind clear "$PANE1"
+[ -z "$(win_color)" ] || die "clear: window @claude_color should be unset, got '$(win_color)'"
+[ -z "$(pane_border "$PANE1")" ] || die "clear: pane 1 border override should be gone"
+expand "$(opt window-status-format)" | grep -qF "#586e75" \
+  || die "clear: window-status-format did not fall back to the default fg"
+if expand "$(opt window-status-current-format)" | grep -qF "✳"; then
+  die "clear: the ✳ marker is still rendered"
+fi
+echo "== clear restores the default colors =="
+
+# 5) outside tmux the hook is a silent no-op (Claude Code also runs in plain
+#    terminals; the hook must not fail there).
+out="$(env -u TMUX -u TMUX_PANE "$DIR/claude_tmux_indicator.sh" waiting 2>&1)" \
+  || die "outside tmux: expected exit 0"
+[ -z "$out" ] || die "outside tmux: expected no output, got '$out'"
+echo "== outside tmux it is a silent no-op =="
+
+echo "PASS"

--- a/bin/claude_tmux_indicator.sh
+++ b/bin/claude_tmux_indicator.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Claude Code hook handler: color the tmux pane border and window-status entry
+# by Claude's state, so the pane that needs attention is visible at a glance
+# from any window.
+#
+#   claude_tmux_indicator.sh waiting   # red    — blocked on the user (permission / idle)
+#   claude_tmux_indicator.sh done      # yellow — finished, ready for the next prompt
+#   claude_tmux_indicator.sh clear     # back to normal (prompt submitted, tool resumed, …)
+#
+# Registered in ~/.claude/settings.json by bin/install_claude_tmux_hooks.sh.
+# It sets the window user option @claude_color (rendered by the
+# window-status-* formats in .tmux.conf) and overrides the flagged pane's
+# border style directly. Outside tmux, or on a tmux too old for per-pane
+# options, it is a silent no-op — a hook must never break a Claude session.
+set -eu
+
+RED="#dc322f"     # Solarized red: Claude is blocked on the user
+YELLOW="#b58900"  # Solarized yellow: Claude finished responding
+
+[ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] || exit 0
+command -v tmux >/dev/null 2>&1 || exit 0
+
+case "${1:-}" in
+  waiting) color="$RED" ;;
+  done)    color="$YELLOW" ;;
+  clear)   color="" ;;
+  *) echo "usage: $0 waiting|done|clear" >&2; exit 2 ;;
+esac
+
+# tmux calls may fail on old servers (< 3.1: no per-pane options) or when the
+# server is already gone; never let that surface as a hook failure.
+t() { tmux "$@" 2>/dev/null || true; }
+
+if [ -n "$color" ]; then
+  t set-option -p -t "$TMUX_PANE" @claude_pane_color "$color"
+  t set-option -p -t "$TMUX_PANE" pane-border-style "fg=$color"
+  t set-option -p -t "$TMUX_PANE" pane-active-border-style "fg=$color,bold"
+else
+  t set-option -pu -t "$TMUX_PANE" @claude_pane_color
+  t set-option -pu -t "$TMUX_PANE" pane-border-style
+  t set-option -pu -t "$TMUX_PANE" pane-active-border-style
+fi
+
+# The window shows the most urgent state left across its panes (red beats
+# yellow), so clearing one pane never hides another that still needs input.
+panes="$(t list-panes -t "$TMUX_PANE" -F '#{@claude_pane_color}')"
+case "$panes" in
+  *"$RED"*)    t set-option -w -t "$TMUX_PANE" @claude_color "$RED" ;;
+  *"$YELLOW"*) t set-option -w -t "$TMUX_PANE" @claude_color "$YELLOW" ;;
+  *)           t set-option -wu -t "$TMUX_PANE" @claude_color ;;
+esac

--- a/bin/install_claude_tmux_hooks.sh
+++ b/bin/install_claude_tmux_hooks.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Register the Claude Code → tmux state-indicator hooks in
+# ~/.claude/settings.json (user level, so every project gets them). jq-merges
+# into the existing file: unrelated settings and hooks are preserved, and
+# reruns are no-ops (idempotent). Called by bin/mkworld.sh; safe to rerun by
+# hand. Never fails the bootstrap — missing jq or a hand-broken settings.json
+# only warns and exits 0.
+set -eu
+
+SETTINGS_DIR="$HOME/.claude"
+SETTINGS="$SETTINGS_DIR/settings.json"
+# Kept unexpanded on purpose: the hook command is run through a shell, so
+# $HOME resolves per machine and settings.json stays portable. ~/bin is the
+# symlink mklink.sh creates.
+# shellcheck disable=SC2016
+INDICATOR='$HOME/bin/claude_tmux_indicator.sh'
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "install_claude_tmux_hooks: jq not found; skipping" >&2
+  exit 0
+fi
+
+mkdir -p "$SETTINGS_DIR"
+[ -f "$SETTINGS" ] || printf '{}\n' >"$SETTINGS"
+
+if ! jq empty "$SETTINGS" 2>/dev/null; then
+  echo "install_claude_tmux_hooks: $SETTINGS is invalid JSON; leaving it untouched" >&2
+  exit 0
+fi
+
+tmp="$(mktemp)"
+jq --arg ind "$INDICATOR" '
+  # Append {type: command, command: $cmd} under .hooks[$event] unless an entry
+  # already runs exactly that command.
+  def ensure($event; $cmd):
+    .hooks[$event] = ((.hooks[$event] // [])
+      | if any(.[]; any(.hooks[]?; .command == $cmd)) then .
+        else . + [{hooks: [{type: "command", command: $cmd}]}] end);
+  ensure("Notification";       $ind + " waiting")  # permission prompt / idle
+  | ensure("Stop";             $ind + " done")     # finished responding
+  | ensure("UserPromptSubmit"; $ind + " clear")
+  | ensure("PreToolUse";       $ind + " clear")    # resumed after a permission grant
+  | ensure("SessionStart";     $ind + " clear")
+  | ensure("SessionEnd";       $ind + " clear")
+' "$SETTINGS" >"$tmp"
+mv "$tmp" "$SETTINGS"
+echo "install_claude_tmux_hooks: indicator hooks present in $SETTINGS"

--- a/bin/mkworld.sh
+++ b/bin/mkworld.sh
@@ -36,6 +36,11 @@ else
     echo "tmux not found on PATH; skipping tmux plugin install" >&2
 fi
 
+# Claude Code: register the tmux state-indicator hooks (pane/window colors for
+# waiting-for-input / finished states) in ~/.claude/settings.json. Idempotent;
+# warns and skips instead of failing when jq is missing.
+sh "$BASE_DIR/bin/install_claude_tmux_hooks.sh"
+
 # Install git hooks (lefthook) and the commit message template
 if command -v lefthook >/dev/null 2>&1; then
     (cd "$BASE_DIR" && lefthook install && git config --local commit.template .gitmessage)

--- a/test/install_claude_tmux_hooks.bats
+++ b/test/install_claude_tmux_hooks.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+# Tests for bin/install_claude_tmux_hooks.sh, the installer that registers the
+# claude_tmux_indicator.sh hooks (pane/window color for Claude Code states) in
+# ~/.claude/settings.json. The installer must be idempotent and must never
+# clobber unrelated user settings — it jq-merges into whatever is already
+# there. Each test runs against a throwaway $HOME.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/install_claude_tmux_hooks.sh"
+  TMP="$(mktemp -d)"
+  export HOME="$TMP/home"
+  mkdir -p "$HOME"
+  SETTINGS="$HOME/.claude/settings.json"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "creates settings.json with every indicator hook on a fresh home" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -f "$SETTINGS" ]
+  jq empty "$SETTINGS"
+  for ev in Notification Stop UserPromptSubmit PreToolUse SessionStart SessionEnd; do
+    jq -e --arg ev "$ev" \
+      '.hooks[$ev][].hooks[] | select(.type == "command" and (.command | contains("claude_tmux_indicator.sh")))' \
+      "$SETTINGS" >/dev/null
+  done
+}
+
+@test "wires each event to the right indicator state" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Notification (permission prompt / idle) = attention; Stop = finished.
+  jq -e '.hooks.Notification[].hooks[] | select(.command | endswith("claude_tmux_indicator.sh waiting"))' \
+    "$SETTINGS" >/dev/null
+  jq -e '.hooks.Stop[].hooks[] | select(.command | endswith("claude_tmux_indicator.sh done"))' \
+    "$SETTINGS" >/dev/null
+  # A new prompt, a resumed tool call, and session start/end all reset it.
+  for ev in UserPromptSubmit PreToolUse SessionStart SessionEnd; do
+    jq -e --arg ev "$ev" \
+      '.hooks[$ev][].hooks[] | select(.command | endswith("claude_tmux_indicator.sh clear"))' \
+      "$SETTINGS" >/dev/null
+  done
+}
+
+@test "is idempotent: a second run changes nothing" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  first="$(cat "$SETTINGS")"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$SETTINGS")" = "$first" ]
+}
+
+@test "preserves unrelated settings and pre-existing hooks" {
+  mkdir -p "$HOME/.claude"
+  cat >"$SETTINGS" <<'EOF'
+{
+  "model": "opus",
+  "hooks": {
+    "Stop": [{"hooks": [{"type": "command", "command": "echo custom-stop"}]}]
+  }
+}
+EOF
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.model' "$SETTINGS")" = "opus" ]
+  jq -e '.hooks.Stop[].hooks[] | select(.command == "echo custom-stop")' "$SETTINGS" >/dev/null
+  jq -e '.hooks.Stop[].hooks[] | select(.command | contains("claude_tmux_indicator.sh"))' "$SETTINGS" >/dev/null
+}
+
+@test "leaves an invalid settings.json untouched and exits 0 (bootstrap-safe)" {
+  mkdir -p "$HOME/.claude"
+  printf '{broken\n' >"$SETTINGS"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$SETTINGS")" = '{broken' ]
+  [[ "$output" == *"invalid"* ]]
+}


### PR DESCRIPTION
## Summary

Make the tmux pane and window running Claude Code visually obvious from anywhere in the session: red when Claude is blocked on the user (permission prompt / idle notification), yellow when it finished responding and is waiting for the next prompt. Driven by Claude Code hooks, rendered by the existing Solarized status-line formats.

## Changes

- `bin/claude_tmux_indicator.sh` — Claude Code hook handler (`waiting` / `done` / `clear`). Sets the window user option `@claude_color` and overrides the pane's border style (red `#dc322f` = blocked on the user, yellow `#b58900` = finished). The window keeps the most urgent color across its panes (red beats yellow); outside tmux it is a silent no-op.
- `.tmux.conf` — `window-status-format` / `window-status-current-format` render `@claude_color` as the entry/pill color plus a `✳` marker, falling back to the existing bell/Solarized palette when unset.
- `bin/install_claude_tmux_hooks.sh` — idempotent jq-merge of the hook registrations (`Notification`/`Stop` → waiting/done; `UserPromptSubmit`, `PreToolUse`, `SessionStart`, `SessionEnd` → clear) into `~/.claude/settings.json`, preserving whatever is already there; refuses to touch a hand-broken file. Wired into `bin/mkworld.sh`.
- `test/install_claude_tmux_hooks.bats` — installer merge logic (fresh home, event wiring, idempotency, preservation of existing settings, invalid-JSON safety).
- `bin/ci_claude_tmux_indicator_test.sh` — e2e driving the real hook script against a real tmux server loaded with the repo `.tmux.conf`; asserts the options set and the rendered formats. Added as a CI step in `.github/workflows/ci.yml`.

## Verification

- TDD: both new tests were written first and proven red (missing implementation), then green after implementing.
- Mutation checks: broke the red color value, the `✳` marker conditional, and the `Stop` event wiring one at a time — each made exactly the expected assertion fail; restored and confirmed green.
- `./bin/ci_claude_tmux_indicator_test.sh`, `./bin/ci_tmux_status_test.sh`, `./bin/ci_tmux_loading_test.sh` all PASS locally (tmux 3.4; loading test with a stubbed tpm since the sandbox can't clone plugins).
- `./bin/lint_shell.sh`, `./bin/lint_editorconfig.sh`, `./bin/run_tests.sh` (113 bats tests) all pass; full lefthook pre-commit suite green.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgK6EoituBtLpbxmFpa1yV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgK6EoituBtLpbxmFpa1yV)_