### PR TITLE
fix(macos): idempotent nvram setup + minor cleanups (4 files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ mysqlsh/*
 .zshrc.local
 
 **/.claude/settings.local.json
+
+**/.claude/.cc-writes/

--- a/Brewfile.common
+++ b/Brewfile.common
@@ -21,8 +21,6 @@ brew "btop"
 brew "check-jsonschema"
 # Apjanke's fork of the classic cowsay project
 brew "cowsay"
-# Reimplementation of ctags(1)
-brew "ctags"
 # Power of curl, ease of use of httpie
 brew "curlie"
 # Structural diff that understands syntax (on-demand via `git dft`)
@@ -121,6 +119,8 @@ brew "silicon"
 brew "telnet"
 # Manage complex tmux sessions easily
 brew "tmuxinator"
+# Maintained, actively developed ctags implementation
+brew "universal-ctags"
 # Vi 'workalike' with many additional features
 brew "vim"
 # Executes a program periodically, showing output fullscreen

--- a/bin/setup_macosx.sh
+++ b/bin/setup_macosx.sh
@@ -18,5 +18,7 @@ defaults write -g AppleShowAllExtensions -bool true
 defaults write -g KeyRepeat -int 1
 defaults write -g InitialKeyRepeat -int 10
 
-# 起動音をミュート
-sudo nvram StartupMute=%01
+# 起動音をミュート（sudoが要るのはここだけなので、既に設定済みならスキップする）
+if [ "$(nvram StartupMute 2>/dev/null | awk '{print $2}')" != "%01" ]; then
+    sudo nvram StartupMute=%01
+fi

--- a/test/setup_macosx.bats
+++ b/test/setup_macosx.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Behavioural tests for bin/setup_macosx.sh. Stubs `defaults`, `nvram`, and
+# `sudo` so no real system state is touched; STUB_STARTUP_MUTE controls what
+# `nvram StartupMute` reports back, letting us assert the sudo nvram write is
+# skipped once it's already set.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/bin/setup_macosx.sh"
+  TMP="$(mktemp -d)"
+  CMD_LOG="$TMP/cmd.log"
+  export CMD_LOG
+
+  STUB="$TMP/stubbin"
+  mkdir -p "$STUB"
+
+  cat >"$STUB/defaults" <<'STUBEOF'
+#!/bin/bash
+echo "defaults $*" >>"$CMD_LOG"
+exit 0
+STUBEOF
+
+  cat >"$STUB/nvram" <<'STUBEOF'
+#!/bin/bash
+echo "nvram $*" >>"$CMD_LOG"
+if [ "$#" -eq 1 ] && [ "$1" = "StartupMute" ]; then
+  echo "StartupMute	${STUB_STARTUP_MUTE:-%00}"
+fi
+exit 0
+STUBEOF
+
+  cat >"$STUB/sudo" <<'STUBEOF'
+#!/bin/bash
+echo "sudo $*" >>"$CMD_LOG"
+exec "$@"
+STUBEOF
+
+  chmod +x "$STUB/defaults" "$STUB/nvram" "$STUB/sudo"
+  PATH="$STUB:$PATH"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "skips sudo nvram when StartupMute is already set" {
+  STUB_STARTUP_MUTE='%01' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run cat "$CMD_LOG"
+  [[ "$output" != *"sudo nvram"* ]]
+}
+
+@test "runs sudo nvram when StartupMute is not yet set" {
+  STUB_STARTUP_MUTE='%00' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run cat "$CMD_LOG"
+  [[ "$output" == *"sudo nvram StartupMute=%01"* ]]
+}
+
+@test "still applies the defaults writes regardless of StartupMute" {
+  STUB_STARTUP_MUTE='%01' run "$SCRIPT"
+  run cat "$CMD_LOG"
+  [[ "$output" == *"defaults write com.apple.finder AppleShowAllFiles -bool YES"* ]]
+}


### PR DESCRIPTION
## Summary

TL;DR: makes `bin/setup_macosx.sh`'s startup-mute nvram write idempotent (no more needless sudo prompt), and folds in two small pending local changes along the way.

<details>
<summary>Details</summary>

`setup_macosx.sh` unconditionally ran `sudo nvram StartupMute=%01` on every invocation, prompting for a password even when the value was already set from a prior run. It now reads the current value first (no sudo needed) and only writes when it differs.

Also bundled in two unrelated local changes that had been sitting uncommitted:
- `Brewfile.common`: swap the unmaintained `ctags` for `universal-ctags`
- `.gitignore`: exclude Claude Code's local checkpoint/undo directory `.claude/.cc-writes/`

</details>

## Changes

- `bin/setup_macosx.sh`: check `nvram StartupMute`'s current value and skip the `sudo nvram` write when it's already `%01`
- `test/setup_macosx.bats`: new stub-based tests covering the idempotent behavior
- `Brewfile.common`: `ctags` → `universal-ctags`
- `.gitignore`: add `**/.claude/.cc-writes/`

## Verification

- `bats test/setup_macosx.bats` — 3/3 green (confirmed red before the fix, for the expected reason)
- `./bin/lint_shell.sh` — clean
- `./bin/check_brewfile_sort.sh Brewfile.common` — sort order OK
- Ran `sh bin/setup_macosx.sh` on a real machine with `StartupMute` already set — no sudo prompt
- `gitleaks git --log-opts "origin/main..HEAD"` — no leaks found

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none