### PR TITLE
fix(tmux): harden the Claude Code indicator (self-review findings)

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -98,11 +98,16 @@ set -g status-left-length 50
 set -g status-right-length 100
 set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #{session_name} #[fg=#268bd2,bg=#073642,nobold] "
 set -g status-right "#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
-# @claude_color is a window user option set by bin/claude_tmux_indicator.sh
-# (Claude Code hooks): red #dc322f = Claude waits for input/permission, yellow
-# #b58900 = finished. When set it overrides the window entry's color and
-# appends a ✳ marker; when unset these formats render exactly as before.
-setw -g window-status-format "#[fg=#{?#{@claude_color},#{@claude_color},#{?window_bell_flag,#dc322f,#586e75}},bg=#073642]#{?#{@claude_color},#[bold],} #I:#W#{?#{@claude_color}, ✳,} "
+# Claude Code state indicator: bin/claude_tmux_indicator.sh tags panes with
+# @claude_state (waiting=red #dc322f, done=yellow #b58900, red wins); the
+# hooks below recompute the window color when panes move or die. Deferred via
+# run-shell -b, and the status formats read only the plain @claude_color:
+# evaluating #{P:} mid-command or at draw time crashes tmux 3.7. Bell keeps
+# priority; with no state set the formats render exactly as before.
+set -g @claude_win_color '#{?#{m:*waiting*,#{P:#{@claude_state}}},#dc322f,#{?#{m:*done*,#{P:#{@claude_state}}},#b58900,}}'
+set-hook -ga window-layout-changed 'run-shell -b "tmux set-option -wF -t \"#{window_id}\" @claude_color \"##{E:@claude_win_color}\""'
+set-hook -ga window-linked 'run-shell -b "tmux set-option -wF -t \"#{window_id}\" @claude_color \"##{E:@claude_win_color}\""'
+setw -g window-status-format "#[fg=#{?window_bell_flag,#dc322f,#{?#{@claude_color},#{@claude_color},#586e75}},bg=#073642]#{?#{@claude_color},#[bold],} #I:#W#{?#{@claude_color}, ✳,} "
 setw -g window-status-current-format "#[fg=#073642,bg=#{?#{@claude_color},#{@claude_color},#2aa198}]#[fg=#002b36,bg=#{?#{@claude_color},#{@claude_color},#2aa198},bold] #I:#W#{?#{@claude_color}, ✳,} #[fg=#{?#{@claude_color},#{@claude_color},#2aa198},bg=#073642]"
 setw -g window-status-separator ""
 

--- a/bin/ci_claude_tmux_indicator_test.sh
+++ b/bin/ci_claude_tmux_indicator_test.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
-# End-to-end test for the Claude Code tmux state indicator
-# (bin/claude_tmux_indicator.sh + the @claude_color conditionals in
-# .tmux.conf). Runs the real hook script against a real tmux server, then
-# asserts both layers: the options the script sets (window @claude_color, the
-# per-pane border overrides) and how the status-line formats render them —
-# expanded with `display-message -p`, exactly as tmux evaluates them when
-# drawing. Covers: waiting (red), done (yellow), red-beats-yellow priority
-# across panes in one window, clear (back to defaults), and the outside-tmux
-# no-op.
+# End-to-end test for the Claude Code tmux state indicator: runs the real
+# hook script (bin/claude_tmux_indicator.sh) against a real tmux server
+# loaded with the repo .tmux.conf and asserts every layer — pane option and
+# border override, the recomputed window color, the resync hooks, and the
+# rendered status formats.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -17,12 +13,14 @@ DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 need tmux
 echo "== $(tmux -V) =="
 
-# The ✳ marker is multibyte; under a non-UTF-8 locale (bare CI shells) tmux
-# renders it as '_' and the glyph assertions below would miss it.
-export LC_ALL=C.UTF-8 LANG=C.UTF-8
-
 CONF="$(tmux_conf_path)"
 echo "== conf under test: $CONF =="
+
+# Pick an available UTF-8 locale (Linux: C.utf8, macOS: en_US.UTF-8) — under
+# a non-UTF-8 locale tmux renders the multibyte ✳ marker as '_'.
+UTF8_LOCALE="$(locale -a 2>/dev/null | grep -iE '^(C|en_US)\.utf-?8$' | head -n1 || true)"
+[ -n "$UTF8_LOCALE" ] || UTF8_LOCALE=en_US.UTF-8
+export LC_ALL="$UTF8_LOCALE" LANG="$UTF8_LOCALE"
 
 RED="#dc322f"
 YELLOW="#b58900"
@@ -37,59 +35,91 @@ tmux -L "$SOCK" -f "$CONF" new-session -d -s "$SESS" -x 200 -y 50 || die "failed
 SOCK_PATH="$(tmux -L "$SOCK" display-message -p '#{socket_path}')"
 PANE1="$(tmux -L "$SOCK" display-message -p '#{pane_id}')"
 
-# Run the hook script the way Claude Code does: as a plain child process that
+# Run the hook script the way Claude Code does: a plain child process that
 # only knows it is inside tmux via $TMUX / $TMUX_PANE.
 ind() { TMUX="$SOCK_PATH,0,0" TMUX_PANE="$2" "$DIR/claude_tmux_indicator.sh" "$1"; }
 
 opt() { tmux -L "$SOCK" show-options -gqv "$1"; }
-win_color() { tmux -L "$SOCK" show-options -wqv -t "$PANE1" @claude_color; }
+pane_state() { tmux -L "$SOCK" show-options -pqv -t "$1" @claude_state; }
 pane_border() { tmux -L "$SOCK" show-options -pqv -t "$1" pane-border-style; }
-expand() { tmux -L "$SOCK" display-message -p "$1" 2>/dev/null | tr -d '\000'; }
+win_color() { tmux -L "$SOCK" show-options -wqv -t "$1" @claude_color; }
+expand_at() { tmux -L "$SOCK" display-message -p -t "$1" "$2" 2>/dev/null | tr -d '\000'; }
+# Hook-driven recomputes are deferred (run-shell -b); poll briefly.
+wait_win_color() { # <target> <expected> <label>
+  local i=0
+  while [ "$i" -lt 20 ]; do
+    [ "$(win_color "$1")" = "$2" ] && return 0
+    i=$((i + 1)); sleep 0.1
+  done
+  die "$3: expected '$2', got '$(win_color "$1")'"
+}
 
-# 1) waiting -> red window option, red pane border, red + marker in both
-#    window-status formats.
+# 0) bell must outrank the indicator, and the resync hooks must be registered
+#    (window-layout-changed is window-scoped -gw; window-linked is -g).
+case "$(opt window-status-format)" in
+  *'fg=#{?window_bell_flag,#dc322f,'*) ;;
+  *) die "bell: window_bell_flag no longer outranks @claude_color in window-status-format" ;;
+esac
+echo "== bell keeps priority over the indicator =="
+tmux -L "$SOCK" show-hooks -gw | grep -q 'window-layout-changed.*@claude_color' \
+  || die "hooks: window-layout-changed does not recompute @claude_color"
+tmux -L "$SOCK" show-hooks -g | grep -q 'window-linked.*@claude_color' \
+  || die "hooks: window-linked does not recompute @claude_color"
+echo "== layout/linked resync hooks are registered =="
+
+# 1) waiting -> red border, red window color, red + ✳ in the formats.
 ind waiting "$PANE1"
-[ "$(win_color)" = "$RED" ] || die "waiting: window @claude_color expected $RED, got '$(win_color)'"
+[ "$(pane_state "$PANE1")" = "waiting" ] \
+  || die "waiting: @claude_state expected 'waiting', got '$(pane_state "$PANE1")'"
 pane_border "$PANE1" | grep -qF "$RED" || die "waiting: pane-border-style not overridden to $RED"
-expand "$(opt window-status-format)" | grep -qF "$RED" \
+[ "$(win_color "$PANE1")" = "$RED" ] || die "waiting: window color expected $RED, got '$(win_color "$PANE1")'"
+expand_at "$PANE1" "$(opt window-status-format)" | grep -qF "$RED" \
   || die "waiting: window-status-format did not render $RED"
-expand "$(opt window-status-current-format)" | grep -qF "$RED" \
+expand_at "$PANE1" "$(opt window-status-current-format)" | grep -qF "$RED" \
   || die "waiting: window-status-current-format did not render $RED"
-expand "$(opt window-status-current-format)" | grep -qF "✳" \
+expand_at "$PANE1" "$(opt window-status-current-format)" | grep -qF "✳" \
   || die "waiting: window-status-current-format did not render the ✳ marker"
 echo "== waiting colors the pane border and window entry red =="
 
-# 2) done -> same pane flips to yellow.
+# 2) done -> the same pane flips to yellow.
 ind 'done' "$PANE1"
-[ "$(win_color)" = "$YELLOW" ] || die "done: window @claude_color expected $YELLOW, got '$(win_color)'"
+[ "$(win_color "$PANE1")" = "$YELLOW" ] \
+  || die "done: window color expected $YELLOW, got '$(win_color "$PANE1")'"
 pane_border "$PANE1" | grep -qF "$YELLOW" || die "done: pane-border-style not overridden to $YELLOW"
 echo "== done colors it yellow =="
 
-# 3) two panes in one window: a waiting (red) pane outranks a done (yellow)
-#    one; clearing the red pane falls back to yellow, not to default.
+# 3) two panes in one window: a waiting (red) pane outranks a done (yellow) one.
 tmux -L "$SOCK" split-window -d -t "$SESS"
 PANE2="$(tmux -L "$SOCK" list-panes -t "$SESS" -F '#{pane_id}' | grep -v "^$PANE1\$" | head -n1)"
 ind waiting "$PANE2"
-[ "$(win_color)" = "$RED" ] || die "priority: red pane should win over yellow, got '$(win_color)'"
-ind clear "$PANE2"
-[ "$(win_color)" = "$YELLOW" ] || die "priority: clearing the red pane should fall back to yellow"
-[ -z "$(pane_border "$PANE2")" ] || die "clear: pane 2 border override should be gone"
-echo "== red beats yellow across panes; clear recomputes the window color =="
+[ "$(win_color "$PANE1")" = "$RED" ] || die "priority: red pane should win over yellow, got '$(win_color "$PANE1")'"
+echo "== red beats yellow across panes =="
 
-# 4) clear on the last flagged pane -> option unset, border override gone,
-#    formats back to the defaults (inactive gray, no marker).
+# 4) the hooks recompute both windows when a pane moves, so the color follows
+#    the pane. join-pane on purpose: tmux 3.7 crashes on ANY break-pane, even
+#    with an empty config (verified with a variant matrix in CI).
+tmux -L "$SOCK" new-window -d -t "$SESS"
+WIN2="$(tmux -L "$SOCK" list-windows -t "$SESS" -F '#{window_id}' | tail -n1)"
+tmux -L "$SOCK" join-pane -d -s "$PANE2" -t "$WIN2"
+wait_win_color "$PANE1" "$YELLOW" "move: origin window should fall back to yellow"
+wait_win_color "$PANE2" "$RED" "move: the red state should follow the moved pane"
+echo "== the indicator follows a moved pane; no stale window color =="
+
+# 5) clear -> everything back to the defaults; a second clear is a no-op.
+ind clear "$PANE2"
+[ -z "$(win_color "$PANE2")" ] || die "clear: pane 2 window color should be empty"
 ind clear "$PANE1"
-[ -z "$(win_color)" ] || die "clear: window @claude_color should be unset, got '$(win_color)'"
+[ -z "$(pane_state "$PANE1")" ] || die "clear: @claude_state should be unset"
 [ -z "$(pane_border "$PANE1")" ] || die "clear: pane 1 border override should be gone"
-expand "$(opt window-status-format)" | grep -qF "#586e75" \
+expand_at "$PANE1" "$(opt window-status-format)" | grep -qF "#586e75" \
   || die "clear: window-status-format did not fall back to the default fg"
-if expand "$(opt window-status-current-format)" | grep -qF "✳"; then
+if expand_at "$PANE1" "$(opt window-status-current-format)" | grep -qF "✳"; then
   die "clear: the ✳ marker is still rendered"
 fi
+ind clear "$PANE1" || die "clear: repeated clear should stay exit 0"
 echo "== clear restores the default colors =="
 
-# 5) outside tmux the hook is a silent no-op (Claude Code also runs in plain
-#    terminals; the hook must not fail there).
+# 6) outside tmux the hook is a silent no-op.
 out="$(env -u TMUX -u TMUX_PANE "$DIR/claude_tmux_indicator.sh" waiting 2>&1)" \
   || die "outside tmux: expected exit 0"
 [ -z "$out" ] || die "outside tmux: expected no output, got '$out'"

--- a/bin/claude_tmux_indicator.sh
+++ b/bin/claude_tmux_indicator.sh
@@ -1,51 +1,39 @@
 #!/bin/sh
-# Claude Code hook handler: color the tmux pane border and window-status entry
-# by Claude's state, so the pane that needs attention is visible at a glance
-# from any window.
-#
-#   claude_tmux_indicator.sh waiting   # red    — blocked on the user (permission / idle)
-#   claude_tmux_indicator.sh done      # yellow — finished, ready for the next prompt
-#   claude_tmux_indicator.sh clear     # back to normal (prompt submitted, tool resumed, …)
-#
-# Registered in ~/.claude/settings.json by bin/install_claude_tmux_hooks.sh.
-# It sets the window user option @claude_color (rendered by the
-# window-status-* formats in .tmux.conf) and overrides the flagged pane's
-# border style directly. Outside tmux, or on a tmux too old for per-pane
-# options, it is a silent no-op — a hook must never break a Claude session.
+# Claude Code hook handler (registered by bin/install_claude_tmux_hooks.sh):
+# color this pane's border and window-status entry by Claude's state.
+#   waiting = red (blocked on the user) / done = yellow (finished) / clear
+# Writes only the pane option @claude_state + border override; the window
+# color @claude_color is recomputed server-side from @claude_win_color (see
+# .tmux.conf) — atomic, so concurrent sessions in one window can't race.
+# Outside tmux this is a silent no-op: a hook must never break a session.
 set -eu
 
-RED="#dc322f"     # Solarized red: Claude is blocked on the user
-YELLOW="#b58900"  # Solarized yellow: Claude finished responding
+RED="#dc322f"
+YELLOW="#b58900"
 
 [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] || exit 0
-command -v tmux >/dev/null 2>&1 || exit 0
 
+color=""
 case "${1:-}" in
-  waiting) color="$RED" ;;
-  done)    color="$YELLOW" ;;
-  clear)   color="" ;;
+  waiting) state=waiting color="$RED" ;;
+  done)    state='done'  color="$YELLOW" ;;
+  clear)   state="" ;;
   *) echo "usage: $0 waiting|done|clear" >&2; exit 2 ;;
 esac
 
-# tmux calls may fail on old servers (< 3.1: no per-pane options) or when the
-# server is already gone; never let that surface as a hook failure.
-t() { tmux "$@" 2>/dev/null || true; }
-
-if [ -n "$color" ]; then
-  t set-option -p -t "$TMUX_PANE" @claude_pane_color "$color"
-  t set-option -p -t "$TMUX_PANE" pane-border-style "fg=$color"
-  t set-option -p -t "$TMUX_PANE" pane-active-border-style "fg=$color,bold"
+if [ -n "$state" ]; then
+  tmux set-option -p -t "$TMUX_PANE" @claude_state "$state" \; \
+       set-option -p -t "$TMUX_PANE" pane-border-style "fg=$color" \; \
+       set-option -p -t "$TMUX_PANE" pane-active-border-style "fg=$color,bold" \; \
+       set-option -wF -t "$TMUX_PANE" @claude_color '#{E:@claude_win_color}' \; \
+       refresh-client -S 2>/dev/null || true
 else
-  t set-option -pu -t "$TMUX_PANE" @claude_pane_color
-  t set-option -pu -t "$TMUX_PANE" pane-border-style
-  t set-option -pu -t "$TMUX_PANE" pane-active-border-style
+  # clear fires on every tool call: exit early when nothing is set.
+  cur="$(tmux display-message -p -t "$TMUX_PANE" '#{@claude_state}' 2>/dev/null || true)"
+  [ -n "$cur" ] || exit 0
+  tmux set-option -pu -t "$TMUX_PANE" @claude_state \; \
+       set-option -pu -t "$TMUX_PANE" pane-border-style \; \
+       set-option -pu -t "$TMUX_PANE" pane-active-border-style \; \
+       set-option -wF -t "$TMUX_PANE" @claude_color '#{E:@claude_win_color}' \; \
+       refresh-client -S 2>/dev/null || true
 fi
-
-# The window shows the most urgent state left across its panes (red beats
-# yellow), so clearing one pane never hides another that still needs input.
-panes="$(t list-panes -t "$TMUX_PANE" -F '#{@claude_pane_color}')"
-case "$panes" in
-  *"$RED"*)    t set-option -w -t "$TMUX_PANE" @claude_color "$RED" ;;
-  *"$YELLOW"*) t set-option -w -t "$TMUX_PANE" @claude_color "$YELLOW" ;;
-  *)           t set-option -wu -t "$TMUX_PANE" @claude_color ;;
-esac

--- a/bin/install_check_tools.sh
+++ b/bin/install_check_tools.sh
@@ -32,11 +32,12 @@ as_root() {
 }
 
 # zsh (zsh-syntax) + shellcheck (shell-lint) + bats (unit tests) + luajit
-# (lua-syntax: parse nvim's Lua with its own runtime) via apt.
+# (lua-syntax: parse nvim's Lua with its own runtime) + jq (unit tests:
+# install_claude_tmux_hooks.sh and its bats suite) via apt.
 if command -v apt-get >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
   as_root apt-get update -qq || true
-  as_root apt-get install -y -qq zsh shellcheck bats luajit >/dev/null
+  as_root apt-get install -y -qq zsh shellcheck bats luajit jq >/dev/null
 fi
 
 # mikefarah yq (config-syntax: `yq -p toml|json|yaml`).

--- a/bin/install_claude_tmux_hooks.sh
+++ b/bin/install_claude_tmux_hooks.sh
@@ -1,47 +1,88 @@
 #!/bin/sh
-# Register the Claude Code → tmux state-indicator hooks in
-# ~/.claude/settings.json (user level, so every project gets them). jq-merges
-# into the existing file: unrelated settings and hooks are preserved, and
-# reruns are no-ops (idempotent). Called by bin/mkworld.sh; safe to rerun by
-# hand. Never fails the bootstrap — missing jq or a hand-broken settings.json
-# only warns and exits 0.
+# Register (default) or remove (--uninstall) the Claude Code → tmux indicator
+# hooks in ~/.claude/settings.json. jq-merge: unrelated settings survive,
+# reruns are no-ops, and anything unexpected only warns — never fails the
+# mkworld bootstrap. rmworld.sh runs --uninstall.
 set -eu
 
 SETTINGS_DIR="$HOME/.claude"
 SETTINGS="$SETTINGS_DIR/settings.json"
-# Kept unexpanded on purpose: the hook command is run through a shell, so
-# $HOME resolves per machine and settings.json stays portable. ~/bin is the
-# symlink mklink.sh creates.
+MODE="${1:-install}"
+
+# Unexpanded on purpose ($HOME resolves per machine at hook runtime); the -x
+# guard keeps the hook a no-op when ~/bin is gone instead of erroring.
 # shellcheck disable=SC2016
-INDICATOR='$HOME/bin/claude_tmux_indicator.sh'
+GUARDED='[ ! -x "$HOME/bin/claude_tmux_indicator.sh" ] || "$HOME/bin/claude_tmux_indicator.sh"'
+
+warn() { echo "install_claude_tmux_hooks: $*" >&2; }
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "install_claude_tmux_hooks: jq not found; skipping" >&2
+  warn "jq not found; skipping"
   exit 0
 fi
+
+case "$MODE" in
+  install) ;;
+  --uninstall)
+    [ -f "$SETTINGS" ] || exit 0 ;;
+  *) echo "usage: $0 [--uninstall]" >&2; exit 2 ;;
+esac
 
 mkdir -p "$SETTINGS_DIR"
 [ -f "$SETTINGS" ] || printf '{}\n' >"$SETTINGS"
 
 if ! jq empty "$SETTINGS" 2>/dev/null; then
-  echo "install_claude_tmux_hooks: $SETTINGS is invalid JSON; leaving it untouched" >&2
+  warn "$SETTINGS is invalid JSON; leaving it untouched"
+  exit 0
+fi
+# Only touch the shape Claude Code documents: hooks = object of arrays of objects.
+if ! jq -e '(.hooks // {}) | type == "object" and all(.[]; type == "array" and all(.[]; type == "object"))' \
+    "$SETTINGS" >/dev/null 2>&1; then
+  warn "$SETTINGS has an unexpected .hooks shape; leaving it untouched"
   exit 0
 fi
 
-tmp="$(mktemp)"
-jq --arg ind "$INDICATOR" '
-  # Append {type: command, command: $cmd} under .hooks[$event] unless an entry
-  # already runs exactly that command.
-  def ensure($event; $cmd):
-    .hooks[$event] = ((.hooks[$event] // [])
-      | if any(.[]; any(.hooks[]?; .command == $cmd)) then .
-        else . + [{hooks: [{type: "command", command: $cmd}]}] end);
-  ensure("Notification";       $ind + " waiting")  # permission prompt / idle
-  | ensure("Stop";             $ind + " done")     # finished responding
-  | ensure("UserPromptSubmit"; $ind + " clear")
-  | ensure("PreToolUse";       $ind + " clear")    # resumed after a permission grant
-  | ensure("SessionStart";     $ind + " clear")
-  | ensure("SessionEnd";       $ind + " clear")
-' "$SETTINGS" >"$tmp"
-mv "$tmp" "$SETTINGS"
-echo "install_claude_tmux_hooks: indicator hooks present in $SETTINGS"
+tmp="$(mktemp "$SETTINGS_DIR/.settings.json.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+# Drop every entry that runs the indicator (any command-string version), so
+# install below is migration-safe strip-then-add.
+STRIP='
+  def strip_indicator:
+    if .hooks == null then .
+    else .hooks |= (with_entries(
+        .value |= map(select(
+          ([.hooks[]? | .command? // empty | strings]
+           | any(contains("claude_tmux_indicator.sh"))) | not))
+      ) | with_entries(select(.value != [])))
+    end;
+'
+
+if [ "$MODE" = "--uninstall" ]; then
+  jq "$STRIP strip_indicator" "$SETTINGS" >"$tmp"
+else
+  jq --arg cmd "$GUARDED" "$STRIP"'
+    def ensure($event; $arg):
+      .hooks[$event] = ((.hooks[$event] // [])
+        + [{hooks: [{type: "command", command: ($cmd + " " + $arg)}]}]);
+    strip_indicator
+    | ensure("Notification";     "waiting")  # permission prompt / idle
+    | ensure("Stop";             "done")     # finished responding
+    | ensure("UserPromptSubmit"; "clear")
+    | ensure("PreToolUse";       "clear")    # fires before any permission prompt
+    | ensure("PostToolUse";      "clear")    # clears the red an approved prompt left
+    | ensure("SessionStart";     "clear")
+    | ensure("SessionEnd";       "clear")
+  ' "$SETTINGS" >"$tmp"
+fi
+
+if cmp -s "$tmp" "$SETTINGS"; then
+  exit 0
+fi
+# cat, not mv: keeps a symlinked settings.json, its permissions and inode.
+cat "$tmp" >"$SETTINGS"
+if [ "$MODE" = "--uninstall" ]; then
+  warn "indicator hooks removed from $SETTINGS"
+else
+  warn "indicator hooks registered in $SETTINGS"
+fi

--- a/bin/rmworld.sh
+++ b/bin/rmworld.sh
@@ -7,7 +7,13 @@
 
 set -eu
 
+BASE_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.."; pwd)
+
 cd "$HOME" || exit 1
+
+# Claude Code のフック登録も外す (mkworld.sh の install と対)。
+# Unregister the Claude Code tmux-indicator hooks (pairs with mkworld.sh).
+sh "$BASE_DIR/bin/install_claude_tmux_hooks.sh" --uninstall || true
 
 # このリポジトリを指すシンボリックリンクのときだけ外す (実ファイルは消さない)。
 # Only remove the entry if it is a symlink (never touch real files).

--- a/test/install_claude_tmux_hooks.bats
+++ b/test/install_claude_tmux_hooks.bats
@@ -1,10 +1,8 @@
 #!/usr/bin/env bats
 
-# Tests for bin/install_claude_tmux_hooks.sh, the installer that registers the
-# claude_tmux_indicator.sh hooks (pane/window color for Claude Code states) in
-# ~/.claude/settings.json. The installer must be idempotent and must never
-# clobber unrelated user settings — it jq-merges into whatever is already
-# there. Each test runs against a throwaway $HOME.
+# Tests for bin/install_claude_tmux_hooks.sh: register/unregister the Claude
+# Code tmux-indicator hooks in ~/.claude/settings.json without ever touching
+# unrelated settings. Each test runs against a throwaway $HOME.
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
@@ -24,7 +22,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -f "$SETTINGS" ]
   jq empty "$SETTINGS"
-  for ev in Notification Stop UserPromptSubmit PreToolUse SessionStart SessionEnd; do
+  for ev in Notification Stop UserPromptSubmit PreToolUse PostToolUse SessionStart SessionEnd; do
     jq -e --arg ev "$ev" \
       '.hooks[$ev][].hooks[] | select(.type == "command" and (.command | contains("claude_tmux_indicator.sh")))' \
       "$SETTINGS" >/dev/null
@@ -35,16 +33,25 @@ teardown() {
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   # Notification (permission prompt / idle) = attention; Stop = finished.
-  jq -e '.hooks.Notification[].hooks[] | select(.command | endswith("claude_tmux_indicator.sh waiting"))' \
-    "$SETTINGS" >/dev/null
-  jq -e '.hooks.Stop[].hooks[] | select(.command | endswith("claude_tmux_indicator.sh done"))' \
-    "$SETTINGS" >/dev/null
-  # A new prompt, a resumed tool call, and session start/end all reset it.
-  for ev in UserPromptSubmit PreToolUse SessionStart SessionEnd; do
+  jq -e '.hooks.Notification[].hooks[] | select(.command | endswith(" waiting"))' "$SETTINGS" >/dev/null
+  jq -e '.hooks.Stop[].hooks[] | select(.command | endswith(" done"))' "$SETTINGS" >/dev/null
+  # A new prompt, tool activity, and session start/end all reset it.
+  for ev in UserPromptSubmit PreToolUse PostToolUse SessionStart SessionEnd; do
     jq -e --arg ev "$ev" \
-      '.hooks[$ev][].hooks[] | select(.command | endswith("claude_tmux_indicator.sh clear"))' \
-      "$SETTINGS" >/dev/null
+      '.hooks[$ev][].hooks[] | select(.command | endswith(" clear"))' "$SETTINGS" >/dev/null
   done
+}
+
+@test "registered commands are guarded so a missing script never errors" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  jq -e '.hooks.Stop[].hooks[]
+           | select(.command | startswith("[ ! -x ") and contains("claude_tmux_indicator.sh"))' \
+    "$SETTINGS" >/dev/null
+  cmd="$(jq -r '.hooks.Stop[].hooks[]
+                  | select(.command | contains("claude_tmux_indicator.sh")).command' "$SETTINGS")"
+  run sh -c "$cmd"   # script does not exist under this fake $HOME
+  [ "$status" -eq 0 ]
 }
 
 @test "is idempotent: a second run changes nothing" {
@@ -54,6 +61,18 @@ teardown() {
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(cat "$SETTINGS")" = "$first" ]
+}
+
+@test "a no-op rerun does not rewrite the file at all" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  touch -t 200001010000 "$SETTINGS"
+  ref="$TMP/ref"
+  touch -t 200101010000 "$ref"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Still older than the reference file -> mtime untouched -> not rewritten.
+  [ "$SETTINGS" -ot "$ref" ]
 }
 
 @test "preserves unrelated settings and pre-existing hooks" {
@@ -71,6 +90,74 @@ EOF
   [ "$(jq -r '.model' "$SETTINGS")" = "opus" ]
   jq -e '.hooks.Stop[].hooks[] | select(.command == "echo custom-stop")' "$SETTINGS" >/dev/null
   jq -e '.hooks.Stop[].hooks[] | select(.command | contains("claude_tmux_indicator.sh"))' "$SETTINGS" >/dev/null
+}
+
+@test "writes through a symlinked settings.json instead of replacing it" {
+  mkdir -p "$HOME/.claude" "$TMP/settings-repo"
+  printf '{"model": "opus"}\n' >"$TMP/settings-repo/settings.json"
+  ln -s "$TMP/settings-repo/settings.json" "$SETTINGS"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -L "$SETTINGS" ]
+  jq -e '.hooks.Stop' "$TMP/settings-repo/settings.json" >/dev/null
+  [ "$(jq -r '.model' "$TMP/settings-repo/settings.json")" = "opus" ]
+}
+
+@test "replaces a stale registration instead of stacking a duplicate" {
+  mkdir -p "$HOME/.claude"
+  cat >"$SETTINGS" <<'EOF'
+{"hooks": {"Notification": [{"hooks": [
+  {"type": "command", "command": "$HOME/bin/claude_tmux_indicator.sh waiting"}]}]}}
+EOF
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  count="$(jq '[.hooks.Notification[].hooks[]
+                 | select(.command | contains("claude_tmux_indicator.sh"))] | length' "$SETTINGS")"
+  [ "$count" -eq 1 ]
+}
+
+@test "--uninstall removes every indicator hook and keeps everything else" {
+  mkdir -p "$HOME/.claude"
+  cat >"$SETTINGS" <<'EOF'
+{
+  "model": "opus",
+  "hooks": {
+    "Stop": [{"hooks": [{"type": "command", "command": "echo custom-stop"}]}]
+  }
+}
+EOF
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run "$SCRIPT" --uninstall
+  [ "$status" -eq 0 ]
+  run jq -e '.. | .command? // empty | select(contains("claude_tmux_indicator.sh"))' "$SETTINGS"
+  [ "$status" -ne 0 ]
+  [ "$(jq -r '.model' "$SETTINGS")" = "opus" ]
+  jq -e '.hooks.Stop[].hooks[] | select(.command == "echo custom-stop")' "$SETTINGS" >/dev/null
+}
+
+@test "--uninstall with no settings.json is a silent no-op" {
+  run "$SCRIPT" --uninstall
+  [ "$status" -eq 0 ]
+  [ ! -e "$SETTINGS" ]
+}
+
+@test "leaves an array-shaped hooks key untouched and exits 0 (bootstrap-safe)" {
+  mkdir -p "$HOME/.claude"
+  printf '{"hooks": []}\n' >"$SETTINGS"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$SETTINGS")" = '{"hooks": []}' ]
+  [[ "$output" == *"unexpected"* ]]
+}
+
+@test "leaves a non-array event value untouched and exits 0 (bootstrap-safe)" {
+  mkdir -p "$HOME/.claude"
+  printf '{"hooks": {"Stop": "not-an-array"}}\n' >"$SETTINGS"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$SETTINGS")" = '{"hooks": {"Stop": "not-an-array"}}' ]
+  [[ "$output" == *"unexpected"* ]]
 }
 
 @test "leaves an invalid settings.json untouched and exits 0 (bootstrap-safe)" {


### PR DESCRIPTION
## Summary

Follow-up to #86: fix the 10 findings from its self-review. The window color is now recomputed from pane state (atomically, inside the tmux server) instead of hand-maintained, and the settings.json installer can no longer break the mkworld bootstrap or clobber a user-managed file.

## Changes

- `bin/claude_tmux_indicator.sh` — tag only its own pane (`@claude_state` + border) and recompute the window color via `set-option -wF` in one chained tmux call (was 5 client spawns); early-exit when there is nothing to clear. Atomic recompute = no race between concurrent sessions in one window.
- `.tmux.conf` — `window-layout-changed` / `window-linked` hooks rerun the recompute when panes move or die (no stale window color); bell outranks the indicator again. The `#{P:}` aggregation stays out of the draw path and in-flight commands — evaluating it there crashes tmux 3.7.
- `bin/install_claude_tmux_hooks.sh` — hook commands guarded with `[ ! -x … ] ||`; unexpected `.hooks` shapes warn instead of aborting mkworld; writes preserve a symlinked settings.json and are skipped when nothing changed; strip-then-add migrates old registrations; new `--uninstall`, wired into `rmworld.sh`; `PostToolUse` clears the red left by an approved permission prompt.
- `bin/install_check_tools.sh` — install jq (bats suite depends on it; CI passed only because the runner image ships it).
- Tests — installer bats extended to 13 cases; e2e covers bell priority, hook registration, and a pane moved across windows; UTF-8 locale picked instead of hardcoding `C.UTF-8` (absent on macOS).

## Verification

- TDD: new expectations run against the merged #86 first (9 bats + 1 e2e failures), then green; mutation checks on the strip logic and hook wiring.
- Found an upstream bug while stabilizing CI: brew tmux 3.7 crashes on **any** `break-pane`, even with an empty config (isolated with a temporary variant matrix in CI, since dropped). The e2e drives the pane move with `join-pane` instead.
- Locally: `ci_claude_tmux_indicator_test` / `ci_tmux_status_test` / `ci_tmux_loading_test`, `lint_shell`, `lint_editorconfig`, 124 bats — all pass. CI green.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgK6EoituBtLpbxmFpa1yV