### PR TITLE
fix(brew): repair broken autoupdate setup script (2 issues)

### DIFF
--- a/bin/setup_brew_autoupdate.sh
+++ b/bin/setup_brew_autoupdate.sh
@@ -49,6 +49,7 @@ if "$BREW_BIN" autoupdate status 2>/dev/null | grep -Eqi 'and running|are enable
 fi
 
 # Start it: update + upgrade (formulae, plus non-greedy casks) + cleanup, weekly,
-# with a macOS notification. No --sudo on purpose (see header).
-"$BREW_BIN" autoupdate start "$INTERVAL" --upgrade --cleanup --enable-notification
+# with a macOS notification (notifications are on by default). No --sudo on
+# purpose (see header).
+"$BREW_BIN" autoupdate start "$INTERVAL" --upgrade --cleanup
 echo "brew autoupdate started: every $INTERVAL s, background upgrade + cleanup."

--- a/bin/setup_brew_autoupdate.sh
+++ b/bin/setup_brew_autoupdate.sh
@@ -39,6 +39,14 @@ if [ -z "$BREW_BIN" ]; then
     exit 0
 fi
 
+# A leftover tap of the pre-official domt4/autoupdate (this command's origin
+# before Homebrew adopted it) provides the same `autoupdate` command name and,
+# being untrusted, makes Homebrew refuse to load either tap's version. Drop it
+# so the official, trusted homebrew/autoupdate tap is unambiguous.
+if "$BREW_BIN" tap 2>/dev/null | grep -qx 'domt4/autoupdate'; then
+    "$BREW_BIN" untap domt4/autoupdate >/dev/null 2>&1 || true
+fi
+
 # Make sure the tap providing the `autoupdate` subcommand is present.
 "$BREW_BIN" tap homebrew/autoupdate >/dev/null 2>&1 || true
 

--- a/test/setup_brew_autoupdate.bats
+++ b/test/setup_brew_autoupdate.bats
@@ -54,7 +54,7 @@ teardown() {
   [ "$status" -eq 0 ]
   run cat "$BREW_LOG"
   [[ "$output" == *"brew tap homebrew/autoupdate"* ]]
-  [[ "$output" == *"brew autoupdate start 604800 --upgrade --cleanup --enable-notification"* ]]
+  [[ "$output" == *"brew autoupdate start 604800 --upgrade --cleanup"* ]]
 }
 
 @test "does not pass --sudo (casks needing a password stay manual)" {

--- a/test/setup_brew_autoupdate.bats
+++ b/test/setup_brew_autoupdate.bats
@@ -24,6 +24,13 @@ STUBEOF
   cat >"$STUB/brew" <<'STUBEOF'
 #!/bin/bash
 echo "brew $*" >>"$BREW_LOG"
+if [ "$1" = "tap" ] && [ "$#" -eq 1 ]; then
+  if [ "${STUB_DOMT4_TAPPED:-0}" = "1" ]; then
+    echo "domt4/autoupdate"
+  fi
+  echo "homebrew/autoupdate"
+  exit 0
+fi
 if [ "$1" = "autoupdate" ] && [ "$2" = "status" ]; then
   if [ "${STUB_RUNNING:-0}" = "1" ]; then
     echo "Autoupdate is installed and running."
@@ -55,6 +62,19 @@ teardown() {
   run cat "$BREW_LOG"
   [[ "$output" == *"brew tap homebrew/autoupdate"* ]]
   [[ "$output" == *"brew autoupdate start 604800 --upgrade --cleanup"* ]]
+}
+
+@test "untaps a leftover untrusted domt4/autoupdate tap before tapping the official one" {
+  STUB_UNAME=Darwin STUB_RUNNING=0 STUB_DOMT4_TAPPED=1 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run cat "$BREW_LOG"
+  [[ "$output" == *"brew untap domt4/autoupdate"* ]]
+}
+
+@test "does not untap anything when domt4/autoupdate is not present" {
+  STUB_UNAME=Darwin STUB_RUNNING=0 run "$SCRIPT"
+  run cat "$BREW_LOG"
+  [[ "$output" != *"untap"* ]]
 }
 
 @test "does not pass --sudo (casks needing a password stay manual)" {


### PR DESCRIPTION
## Summary

TL;DR: fixes two separate ways `bin/setup_brew_autoupdate.sh` was failing outright on a real macOS machine.

<details>
<summary>Details</summary>

1. `brew autoupdate start` was passing `--enable-notification`, an option `homebrew/autoupdate` has since dropped (notifications are on by default now, tunable via `--notify-on-error`/`--no-notify`). The script failed with "invalid option" and never scheduled anything.
2. A leftover `domt4/autoupdate` tap (this command's pre-official-adoption origin) can end up installed alongside the official `homebrew/autoupdate` tap. Both provide the same `autoupdate` command name, and since Homebrew now requires non-official taps to be explicitly trusted, it refuses to load either — breaking both `brew autoupdate status` and `start`. The script now untaps the leftover `domt4/autoupdate` first when present.

</details>

## Changes

- `bin/setup_brew_autoupdate.sh`: drop `--enable-notification`; untap a leftover untrusted `domt4/autoupdate` before tapping the official `homebrew/autoupdate`
- `test/setup_brew_autoupdate.bats`: update the flag expectation; add coverage for the untap behavior (present vs. absent)

## Verification

- `bats test/setup_brew_autoupdate.bats` — 7/7 green (confirmed each new/changed assertion red before its fix, for the expected reason)
- `./bin/lint_shell.sh` — clean
- Reproduced both failures live on a real machine and confirmed `brew autoupdate status`/`start` succeed after the fix
- `gitleaks git --log-opts "main..HEAD"` — no leaks found

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none