### PR TITLE
fix(zsh): cut shell startup time and per-prompt lag

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -82,8 +82,23 @@ sudo_path=(
 # brew shellenv is not eval'd here: its output is static per machine, so it is
 # cached via the brew-shellenv _evalcache inline in config/sheldon/plugins.toml.
 # The path=() block above already puts brew itself on PATH.
+# `sheldon source` output is cached; regenerated when plugins.toml or the
+# lock file changes, kept on failure. Delete the cache to force a rebuild.
 if builtin command -v sheldon >/dev/null; then
-  eval "$(sheldon source)"
+  _sheldon_cache="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/sheldon.zsh"
+  _sheldon_toml="${XDG_CONFIG_HOME:-$HOME/.config}/sheldon/plugins.toml"
+  _sheldon_lock="${XDG_DATA_HOME:-$HOME/.local/share}/sheldon/plugins.lock"
+  if [[ ! -s "$_sheldon_cache" || "$_sheldon_toml" -nt "$_sheldon_cache" \
+        || "$_sheldon_lock" -nt "$_sheldon_cache" ]]; then
+    mkdir -p "${_sheldon_cache:h}"
+    if sheldon source >| "$_sheldon_cache.new"; then
+      mv -f "$_sheldon_cache.new" "$_sheldon_cache"
+    else
+      rm -f "$_sheldon_cache.new"
+    fi
+  fi
+  [[ -s "$_sheldon_cache" ]] && source "$_sheldon_cache"
+  unset _sheldon_cache _sheldon_toml _sheldon_lock
 fi
 
 # CI strict mode: fail on actual command errors during .zshrc load.
@@ -105,6 +120,7 @@ setopt pushdignoredups # 重複を記録しない
 setopt interactivecomments # コメントを有効化
 setopt share_history # historyを共有
 setopt incappendhistory # incrementalに追加
+setopt hist_fcntl_lock # fcntl histfile locking: cheaper than the default per-command lockfile dance
 setopt multios # 複数のリダイレクトやパイプに対応
 setopt extended_history # ヒストリに時刻を追加
 setopt noclobber # リダイレクトで上書き禁止
@@ -126,8 +142,10 @@ setopt globdots # dotも補完
 # history & shell vars
 #=====================
 HISTFILE=~/.zsh_history
-HISTSIZE=9999999
-SAVEHIST=9999999
+# Capped: an untrimmed histfile is parsed whole at every startup and gets
+# slower forever (~1.5s at 2M entries vs ~50ms at 100k).
+HISTSIZE=100000
+SAVEHIST=100000
 MAILCHECK=0
 WORDCHARS='*?_-.[]~=&;!#$%^(){}<>'
 watch=notme # watch and notify, other login user

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,9 @@ truth, so the two never diverge.
 - An auto-created PR (web/remote) starts with an empty body — the template is
   only injected by the GitHub UI; backfill it from the template before anything.
 - Claude Code auto-appends its PR-body / commit trailers — don't remove them.
+- After creating a PR from a session that can receive PR events, subscribe to
+  its activity (`subscribe_pr_activity`) right away without asking — watch CI
+  and review comments and act on them until the PR is merged or closed.
 
 ### Language
 

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -19,15 +19,10 @@ apply = ['source']
 github = 'zsh-users/zsh-completions'
 apply = ['defer']
 
-[plugins.zsh-autosuggestions]
-github = "zsh-users/zsh-autosuggestions"
-apply = ['defer']
-
-[plugins.zsh-autosuggestions.hooks]
-post = "export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=60'"
-
+# Slow init; nothing needs `abbr` before the first prompt.
 [plugins.zsh-abbr]
 github = 'olets/zsh-abbr'
+apply = ['defer']
 
 [plugins.fast-syntax-highlighting]
 github = 'zdharma-continuum/fast-syntax-highlighting'
@@ -35,6 +30,20 @@ apply = ['defer']
 
 [plugins.fast-syntax-highlighting.hooks]
 post = "test -e ~/.cache/fsh/current_theme.zsh || { command -v fast-theme >/dev/null && fast-theme -q ~/.config/fsh/solarized.ini --secondary=zdharma; }"
+
+# Deferred last: MANUAL_REBIND skips the per-precmd widget rebind, which is
+# only safe when no plugin defines widgets after this one loads.
+[plugins.zsh-autosuggestions]
+github = "zsh-users/zsh-autosuggestions"
+apply = ['defer']
+
+[plugins.zsh-autosuggestions.hooks]
+post = """
+export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=60'
+export ZSH_AUTOSUGGEST_MANUAL_REBIND=1
+export ZSH_AUTOSUGGEST_USE_ASYNC=1
+export ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=500
+"""
 
 #================
 # eval cache
@@ -78,5 +87,6 @@ inline = '_evalcache carapace _carapace zsh'
 
 [templates]
 defer = "{{ hooks?.pre | nl }}{% for file in files %}zsh-defer source \"{{ file }}\"\n{% endfor %}{{ hooks?.post | nl }}"
-fzf-install = "{{ dir }}/install --bin > /dev/null \n[[ ! $PATH == *{{ dir }}* ]] && export PATH=\"$PATH:{{ dir }}/bin\"\n"
+# Run fzf's install script only when no fzf binary is present yet.
+fzf-install = "(( $+commands[fzf] )) || [[ -x \"{{ dir }}/bin/fzf\" ]] || {{ dir }}/install --bin > /dev/null\n[[ ! $PATH == *{{ dir }}* ]] && export PATH=\"$PATH:{{ dir }}/bin\"\n"
 fzf-source = "{% for file in files %}source \"{{ file }}\"\n{% endfor %}"


### PR DESCRIPTION
## Summary

Reduce zsh startup time and post-command (per-prompt) lag. The main culprit for the gradual slowdown is the unbounded histfile: with `HISTSIZE=9999999` zsh never trims it and parses the whole file at every startup (measured ~1.5–2.9s at 2M entries vs ~55ms at 100k).

## Changes

- Cap `HISTSIZE`/`SAVEHIST` at 100k so the histfile stops growing without bound. Note: entries beyond 100k will eventually be trimmed — back up `~/.zsh_history` first if you want the full archive.
- Cache `sheldon source` output to a file and source that; regenerated when `plugins.toml` or sheldon's lock file changes, previous cache kept if regeneration fails.
- Defer `zsh-abbr` (slow init; nothing needs `abbr` before the first prompt).
- Move `zsh-autosuggestions` to be the last deferred plugin and set `ZSH_AUTOSUGGEST_MANUAL_REBIND` (stops re-binding every zle widget on each precmd), plus `USE_ASYNC` and `BUFFER_MAX_SIZE=500`.
- Guard fzf's install script behind a binary check instead of forking bash on every startup.
- `setopt hist_fcntl_lock` for cheaper histfile locking with `share_history`.
- AGENTS.md: after creating a PR from an event-capable session, subscribe to its activity right away without asking (per user request).

## Verification

- Benchmarked history load: synthetic 2M-entry histfile ≈ 1.5–2.9s vs 100k ≈ 55ms (`zsh -d` + `fc -R`).
- Tested the sheldon cache block with a stub sheldon binary: cache miss generates, hit skips the fork, touching `plugins.toml`/`plugins.lock` regenerates, and a failing `sheldon source` falls back to the previous cache.
- `zsh -n .zshrc`, `bin/lint_zsh.sh`, `bin/lint_config.sh`, `bin/lint_editorconfig.sh` all pass.
- Interactive load smoke test (`ZDOTDIR=$PWD zsh -ic …`) confirms `HISTSIZE=100000` and `hist_fcntl_lock` take effect. Full e2e (`ci_zsh_loading_test.sh`) needs sheldon/starship, so it runs in CI.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LT66RqibT9SCEnL1vSxRTb