### PR TITLE
fix(zsh): remove hidden per-startup forks (evalcache md5, sync check)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ config/*
 !config/mise/
 !config/nvim/
 !config/sheldon/
+!config/zsh/
 !config/zsh-abbr/
 !config/starship.toml
 !config/starship_sub.toml

--- a/.zshrc
+++ b/.zshrc
@@ -433,7 +433,9 @@ source-if-exist "$HOME/.zshrc.local"
 #=====================
 # Remind at startup when the dotfiles repo needs syncing between machines
 # (uncommitted / unpushed / behind upstream) so updates aren't forgotten when
-# hopping between home and office. Skipped in CI via DOTFILES_NO_SYNC_CHECK.
+# hopping between home and office. Notify-only: prints the cached result and
+# refreshes it in a background job, so startup never blocks on git (the
+# warning can be one shell stale). Skipped in CI via DOTFILES_NO_SYNC_CHECK.
 if [[ -z "${DOTFILES_NO_SYNC_CHECK:-}" ]]; then
   _dotfiles_dir="${${(%):-%x}:A:h}"
   [[ -x "$_dotfiles_dir/bin/dotfiles_sync_check.sh" ]] && "$_dotfiles_dir/bin/dotfiles_sync_check.sh"

--- a/bin/dotfiles_sync_check.sh
+++ b/bin/dotfiles_sync_check.sh
@@ -8,11 +8,13 @@
 #   - committed but unpushed      -> forgot to push
 #   - upstream has new commits    -> forgot to pull
 #
-# Local state (dirty / ahead) is checked every time because it is cheap.
-# Remote state (behind) relies on the remote-tracking ref, which is refreshed
-# by a background `git fetch` at most once per 24h so shell startup is never
-# blocked on the network. The "behind" warning can therefore be one session
-# stale, which is an acceptable trade-off for instant startup.
+# Notify-only, never blocking: the foreground just prints the cached result of
+# the previous run, then a detached background job recomputes the local state
+# (dirty / ahead / behind) for the next shell — the same trade-off
+# brew_bundle_check.sh makes, so a warning can be one shell stale. The local
+# recompute runs every startup (it is cheap); the remote-tracking ref it reads
+# is refreshed by a background `git fetch` at most once per 24h, so the
+# "behind" warning may additionally lag one fetch window.
 #
 # Skipped entirely when DOTFILES_NO_SYNC_CHECK is set (used by CI so the load
 # test neither touches the network nor prints reminder noise).
@@ -23,56 +25,76 @@ set -u
 
 REPO_DIR=$(cd "$(dirname "$(readlink -f "$0")")/.." 2>/dev/null && pwd) || exit 0
 
-# Only proceed inside a git work tree.
-git -C "$REPO_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
-
 cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles"
 mkdir -p "$cache_dir" 2>/dev/null || true
 fetch_stamp="$cache_dir/last_fetch"
+result="$cache_dir/sync_status"
 
-# Refresh the remote-tracking ref at most once per 24h, in the background.
-need_fetch=1
-if [ -f "$fetch_stamp" ]; then
-    last=$(cat "$fetch_stamp" 2>/dev/null || echo 0)
-    case "$last" in
-        '' | *[!0-9]*) last=0 ;;
-    esac
-    if [ "$(( $(date +%s) - last ))" -lt 86400 ]; then
-        need_fetch=0
+#---------------------------------------------------------------
+# foreground: print the cached result and get out of the way
+#---------------------------------------------------------------
+[ -s "$result" ] && cat "$result" >&2
+
+#---------------------------------------------------------------
+# background: refresh the cache for the next shell
+#---------------------------------------------------------------
+# All fds are detached so neither the terminal nor the caller (zsh startup, or
+# bats' fd 3) ever waits on this job.
+(
+    # Only proceed inside a git work tree.
+    git -C "$REPO_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+    yellow=$'\033[33m'
+    cyan=$'\033[36m'
+    reset=$'\033[0m'
+
+    tmp="$result.tmp.$$"
+    : >"$tmp" 2>/dev/null || exit 0
+
+    note() {
+        # $1: message, $2: suggested command
+        printf '%s[dotfiles]%s %s -> %s%s%s\n' \
+            "$yellow" "$reset" "$1" "$cyan" "$2" "$reset" >>"$tmp"
+    }
+
+    # 1) Uncommitted changes (forgot to commit).
+    if [ -n "$(git -C "$REPO_DIR" status --porcelain 2>/dev/null)" ]; then
+        note "uncommitted changes" "git -C $REPO_DIR add -A && git -C $REPO_DIR commit"
     fi
-fi
-if [ "$need_fetch" -eq 1 ]; then
+
+    # 2) Unpushed commits / 3) behind upstream (forgot to push / pull).
+    if git -C "$REPO_DIR" rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1; then
+        counts=$(git -C "$REPO_DIR" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null || echo '')
+        behind=$(printf '%s' "$counts" | awk '{print $1}')
+        ahead=$(printf '%s' "$counts" | awk '{print $2}')
+        if [ "${ahead:-0}" -gt 0 ] 2>/dev/null; then
+            note "${ahead} unpushed commit(s)" "git -C $REPO_DIR push"
+        fi
+        if [ "${behind:-0}" -gt 0 ] 2>/dev/null; then
+            note "${behind} commit(s) behind upstream" "git -C $REPO_DIR pull"
+        fi
+    fi
+
+    # Replaced atomically so a shell reading mid-write never sees a torn file.
+    mv -f "$tmp" "$result" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+
+    # Refresh the remote-tracking ref at most once per 24h. Runs after the
+    # status write so a slow network never delays the next shell's warning.
     # Stamp is written only on success so an offline machine keeps retrying.
-    ( git -C "$REPO_DIR" fetch --quiet --prune 2>/dev/null \
-        && date +%s >"$fetch_stamp" 2>/dev/null ) &
-fi
-
-yellow=$'\033[33m'
-cyan=$'\033[36m'
-reset=$'\033[0m'
-
-note() {
-    # $1: message, $2: suggested command
-    printf '%s[dotfiles]%s %s -> %s%s%s\n' \
-        "$yellow" "$reset" "$1" "$cyan" "$2" "$reset" >&2
-}
-
-# 1) Uncommitted changes (forgot to commit).
-if [ -n "$(git -C "$REPO_DIR" status --porcelain 2>/dev/null)" ]; then
-    note "uncommitted changes" "git -C $REPO_DIR add -A && git -C $REPO_DIR commit"
-fi
-
-# 2) Unpushed commits / 3) behind upstream (forgot to push / pull).
-if git -C "$REPO_DIR" rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1; then
-    counts=$(git -C "$REPO_DIR" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null || echo '')
-    behind=$(printf '%s' "$counts" | awk '{print $1}')
-    ahead=$(printf '%s' "$counts" | awk '{print $2}')
-    if [ "${ahead:-0}" -gt 0 ] 2>/dev/null; then
-        note "${ahead} unpushed commit(s)" "git -C $REPO_DIR push"
+    need_fetch=1
+    if [ -f "$fetch_stamp" ]; then
+        last=$(cat "$fetch_stamp" 2>/dev/null || echo 0)
+        case "$last" in
+            '' | *[!0-9]*) last=0 ;;
+        esac
+        if [ "$(( $(date +%s) - last ))" -lt 86400 ]; then
+            need_fetch=0
+        fi
     fi
-    if [ "${behind:-0}" -gt 0 ] 2>/dev/null; then
-        note "${behind} commit(s) behind upstream" "git -C $REPO_DIR pull"
+    if [ "$need_fetch" -eq 1 ]; then
+        git -C "$REPO_DIR" fetch --quiet --prune 2>/dev/null \
+            && date +%s >"$fetch_stamp" 2>/dev/null
     fi
-fi
+) >/dev/null 2>&1 3>&- </dev/null &
 
 exit 0

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -12,6 +12,11 @@ apply = ['fzf-install', 'fzf-source']
 github = 'mroth/evalcache'
 apply = ['source']
 
+# Replace _evalcache with a no-fork variant (upstream forks md5 per call just
+# to name the cache file). Must load before the _evalcache inlines below.
+[plugins.evalcache.hooks]
+post = 'source "${XDG_CONFIG_HOME:-$HOME/.config}/zsh/evalcache-no-fork.zsh"'
+
 #================
 # defer loading
 #================

--- a/config/zsh/evalcache-no-fork.zsh
+++ b/config/zsh/evalcache-no-fork.zsh
@@ -1,0 +1,25 @@
+# Overrides mroth/evalcache's _evalcache (sourced right after the plugin via
+# its sheldon post hook). Upstream builds the cache filename by piping the
+# command string through md5/md5sum — a fork per call, ~3ms on Linux and ~10ms
+# on macOS, paid on every startup even when all caches hit. Derive the name
+# from the sanitized command string instead: no fork, still unique per command
+# line, and still matches the init-*.sh pattern _evalcache_clear expects.
+# Filenames differ from upstream's, so switching regenerates each cache once.
+_evalcache () {
+  local cacheDir="${ZSH_EVALCACHE_DIR:-$HOME/.zsh-evalcache}"
+  local cacheFile="$cacheDir/init-${${(j:-:)@}//[^A-Za-z0-9_.-]/-}.sh"
+  if [[ "$ZSH_EVALCACHE_DISABLE" == "true" ]]; then
+    eval "$("$@")"
+  elif [[ -s "$cacheFile" ]]; then
+    source "$cacheFile"
+  elif builtin type "$1" >/dev/null 2>&1; then
+    echo "evalcache: $1 initialization not cached, caching output of: $*" >&2
+    mkdir -p "$cacheDir"
+    "$@" >| "$cacheFile"
+    zcompile "$cacheFile" # like upstream (mroth/evalcache#13): parse once, source the wordcode after
+    source "$cacheFile"
+  else
+    echo "evalcache: ERROR: $1 is not installed or in PATH" >&2
+    return 1
+  fi
+}

--- a/test/dotfiles_sync_check.bats
+++ b/test/dotfiles_sync_check.bats
@@ -3,6 +3,11 @@
 # Behavioural tests for bin/dotfiles_sync_check.sh, the shell-startup reminder
 # that nags when the dotfiles repo is out of sync between machines.
 #
+# The script only prints the cached result of the *previous* run and recomputes
+# the state in a detached background job (same design as brew_bundle_check.sh),
+# so most tests assert in two steps: run once, wait_for the background refresh,
+# then run again to observe the nag.
+#
 # The script always inspects its OWN repo (dirname "$0"/..), so each test runs
 # a *copy* of the script placed inside a throwaway git repo. That repo is wired
 # to a local bare "remote" to exercise the ahead/behind branches without any
@@ -16,6 +21,7 @@ setup() {
   SRC="$REPO_ROOT/bin/dotfiles_sync_check.sh"
   TMP="$(mktemp -d)"
   export XDG_CACHE_HOME="$TMP/cache"
+  CACHE="$XDG_CACHE_HOME/dotfiles"
 
   REPO="$TMP/repo"
   mkdir -p "$REPO/bin"
@@ -36,6 +42,13 @@ setup() {
 }
 
 teardown() {
+  # A detached background refresh may still be recreating git lock files under
+  # $TMP while we delete it; retry until the tree stays gone.
+  for _ in $(seq 1 20); do
+    rm -rf "$TMP" 2>/dev/null
+    [ ! -e "$TMP" ] && return 0
+    sleep 0.1
+  done
   rm -rf "$TMP"
 }
 
@@ -46,14 +59,42 @@ add_upstream() {
   git -C "$REPO" push -q -u origin main
 }
 
+# Poll until the condition holds (~5s timeout) — the detached background
+# refresh leaves no process handle to wait on.
+wait_for() {
+  for _ in $(seq 1 50); do
+    eval "$1" && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for: $1" >&2
+  return 1
+}
+
 @test "DOTFILES_NO_SYNC_CHECK short-circuits with no output" {
   echo dirty >>"$REPO/seed.txt"          # would otherwise warn
   DOTFILES_NO_SYNC_CHECK=1 run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+  # And no background job was spawned either.
+  sleep 1
+  [ ! -f "$CACHE/sync_status" ]
 }
 
-@test "clean repo with no upstream is silent" {
+@test "first run is silent and populates the cache in the background" {
+  echo dirty >>"$REPO/seed.txt"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  wait_for '[ -s "$CACHE/sync_status" ]'
+}
+
+@test "clean repo with no upstream stays silent across runs" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  # The result cache exists but is empty.
+  wait_for '[ -f "$CACHE/sync_status" ]'
+  [ ! -s "$CACHE/sync_status" ]
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
@@ -62,12 +103,16 @@ add_upstream() {
 @test "warns about uncommitted changes" {
   echo dirty >>"$REPO/seed.txt"
   run "$SCRIPT"
+  wait_for '[ -s "$CACHE/sync_status" ]'
+  run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"uncommitted changes"* ]]
 }
 
 @test "warns about untracked files too" {
   echo new >"$REPO/untracked.txt"
+  run "$SCRIPT"
+  wait_for '[ -s "$CACHE/sync_status" ]'
   run "$SCRIPT"
   [[ "$output" == *"uncommitted changes"* ]]
 }
@@ -76,6 +121,8 @@ add_upstream() {
   add_upstream
   echo more >>"$REPO/seed.txt"
   git -C "$REPO" commit -qam "feat: ahead"
+  run "$SCRIPT"
+  wait_for '[ -s "$CACHE/sync_status" ]'
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"unpushed commit"* ]]
@@ -95,7 +142,36 @@ add_upstream() {
   git -C "$REPO" fetch -q origin
 
   run "$SCRIPT"
+  wait_for '[ -s "$CACHE/sync_status" ]'
+  run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"behind upstream"* ]]
   [[ "$output" != *"unpushed commit"* ]]
+}
+
+@test "stale warning clears one run after the repo becomes clean" {
+  echo dirty >>"$REPO/seed.txt"
+  run "$SCRIPT"
+  wait_for '[ -s "$CACHE/sync_status" ]'
+  # Repo becomes clean; this run still shows the (stale) cached warning.
+  git -C "$REPO" checkout -q -- seed.txt
+  run "$SCRIPT"
+  [[ "$output" == *"uncommitted changes"* ]]
+  wait_for '[ ! -s "$CACHE/sync_status" ]'
+  run "$SCRIPT"
+  [ -z "$output" ]
+}
+
+@test "startup does not block on a slow git" {
+  # Stub git: any invocation sleeps 3s. The foreground must return before even
+  # a single git call could have finished.
+  STUB="$TMP/stubbin"
+  mkdir -p "$STUB"
+  printf '#!/bin/bash\nsleep 3\nexit 0\n' >"$STUB/git"
+  chmod +x "$STUB/git"
+
+  start=$(date +%s)
+  PATH="$STUB:$PATH" "$SCRIPT" >/dev/null 2>&1
+  elapsed=$(( $(date +%s) - start ))
+  [ "$elapsed" -lt 3 ]
 }


### PR DESCRIPTION
## Summary

Two hidden per-startup fork costs removed: evalcache's md5 fork per call (~25ms across 8 inlines, ~74ms on macOS, paid even on cache hits) and dotfiles_sync_check's foreground git checks (~25ms).

## Changes

- `config/zsh/evalcache-no-fork.zsh`: `_evalcache` override — cache filename from the sanitized command string (no md5 fork) + `zcompile`, loaded via the evalcache plugin's sheldon post hook. Compatible with `ZSH_EVALCACHE_DIR`/`DISABLE`/`_evalcache_clear`; caches regenerate once. `.gitignore` allow-lists `config/zsh/`.
- `bin/dotfiles_sync_check.sh`: same design as brew_bundle_check — foreground only prints the cached result (25ms → 8ms), a detached background job recomputes state for the next shell (warning can be one shell stale). The 24h-gated fetch runs after the status write.

## Verification

- evalcache override: all paths tested in `zsh -df` (miss/hit/DISABLE/missing command); 8 hits = 0.3ms vs 25.7ms upstream.
- sync check: bats rewritten to the two-step contract, proven red against the old script first; 9/9 × 3 runs; new slow-git non-blocking test. Full suite 129/129.
- lint_zsh / lint_config / lint_shell / lint_editorconfig pass.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Follow-up to #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LT66RqibT9SCEnL1vSxRTb