### PR TITLE
feat(tmux): add session switch keybinding (2 files)

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -40,6 +40,10 @@ bind-key -n M-l select-pane -R
 bind-key -n M-Left previous-window
 bind-key -n M-Right next-window
 
+# command+option+↑/↓でsession移動
+bind-key -n M-Up switch-client -p
+bind-key -n M-Down switch-client -n
+
 # pane move: m でmark → M で移動
 bind-key M join-pane -s .
 

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -19,9 +19,11 @@ keybind = super+digit_6=text:\x1b6
 keybind = super+digit_7=text:\x1b7
 keybind = super+digit_8=text:\x1b8
 keybind = super+digit_9=text:\x1b9
-# command+option+←/→でtmux window移動 (デフォルトのgoto_splitはtmux常駐のため未使用)
+# command+option+←/→/↑/↓でtmux window/session移動 (デフォルトのgoto_splitはtmux常駐のため未使用)
 keybind = super+alt+arrow_left=text:\x1b[1;3D
 keybind = super+alt+arrow_right=text:\x1b[1;3C
+keybind = super+alt+arrow_up=text:\x1b[1;3A
+keybind = super+alt+arrow_down=text:\x1b[1;3B
 keybind = super+shift+o=toggle_background_opacity
 
 # Alt+数字はAeroSpaceのワークスペース切り替えに使うため素通しさせる


### PR DESCRIPTION
## Summary

Add `command+option+up/down` to switch tmux sessions, mirroring the existing `left/right` window-switch keybinding.

## Changes

- `.tmux.conf`: bind `M-Up`/`M-Down` to `switch-client -p`/`switch-client -n`
- `config/ghostty/config`: map `super+alt+arrow_up`/`arrow_down` to the matching escape sequences; update the comment to cover `left/right/up/down`

## Verification

- No runtime test; config-only change validated by CI (shell-lint / config-syntax).

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
