### PR TITLE
fix(zsh): mise shims + tmux prompt-mark guard (2 fixes)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -385,8 +385,12 @@ add-zsh-hook precmd update_tmux_window
 # Emit OSC 133;A so tmux can track prompt positions (next-prompt/previous-prompt in copy mode).
 # Prepend to PROMPT (after Starship sets it) so the mark lands at the exact moment zsh draws
 # the prompt, avoiding cursor-position races with Starship's own terminal sequences.
+# $PROMPT persists across precmd calls (Starship sets it once to a string containing a
+# `$(...)` substitution zsh re-evaluates at render time), so the prepend must be guarded —
+# otherwise every prompt in a long-lived tmux session stacks another marker onto it forever.
 _tmux_prompt_mark() {
   [[ -n "$TMUX" ]] || return
+  [[ "$PROMPT" == $'%{\e]133;A\a%}'* ]] && return
   PROMPT=$'%{\e]133;A\a%}'"$PROMPT"
 }
 add-zsh-hook precmd _tmux_prompt_mark

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -67,7 +67,7 @@ inline = '_evalcache starship init zsh'
 inline = '_evalcache zoxide init zsh'
 
 [plugins.mise]
-inline = '_evalcache mise activate zsh'
+inline = '_evalcache mise activate zsh --shims'
 
 [plugins.direnv]
 inline = '_evalcache direnv hook zsh'

--- a/test/tmux_prompt_mark.bats
+++ b/test/tmux_prompt_mark.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# Regression test for the tmux OSC 133;A prompt-mark hook in .zshrc.
+#
+# _tmux_prompt_mark runs as a precmd hook so tmux can track prompt positions
+# (next-prompt/previous-prompt in copy mode). It used to unconditionally
+# prepend the marker to $PROMPT every time, but $PROMPT is a persistent shell
+# variable (starship sets it once, to a string containing a `$(...)` command
+# substitution that zsh re-evaluates at render time) — nothing resets it
+# between precmd calls. Without a guard, every single prompt draw in a
+# long-lived tmux session added another marker, so $PROMPT — and the escape
+# bytes sent to the terminal on every render — grew without bound.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
+@test "_tmux_prompt_mark does not grow PROMPT across repeated precmd cycles" {
+  run zsh -f -c "
+    export ZDOTDIR='$REPO_ROOT'
+    export DOTFILES_NO_SYNC_CHECK=1
+    export DOTFILES_NO_BREW_CHECK=1
+    export TMUX=/tmp/fake-tmux-socket,1,0
+    source '$REPO_ROOT/.zshrc' >/dev/null 2>&1
+    for i in 1 2 3 4 5; do
+      _tmux_prompt_mark
+      print -r -- \${#PROMPT}
+    done
+  "
+  [ "$status" -eq 0 ]
+  # lines[0] is the first call (establishes the marker, expected to grow once);
+  # every call after that must be a no-op on length.
+  [ "${lines[1]}" -eq "${lines[2]}" ]
+  [ "${lines[2]}" -eq "${lines[3]}" ]
+  [ "${lines[3]}" -eq "${lines[4]}" ]
+}


### PR DESCRIPTION
## Summary

Two small leftover fixes from the zsh-startup investigation (same series as #90/#91): switch mise to shims-based activation, and stop a tmux prompt marker from growing unbounded.

## Changes

- `config/sheldon/plugins.toml`: add `--shims` to `mise activate zsh`, switching from the hook-env method (PATH rewritten on every precmd) to shims (PATH set once); `mise doctor` confirms `shims_on_path: yes`.
- `.zshrc`: guard `_tmux_prompt_mark` so the OSC 133;A marker is prepended to `$PROMPT` only once. `$PROMPT` persists across precmd calls, so without the guard a long-lived tmux session accumulated one extra marker per prompt render, forever.

## Verification

- `bats test/tmux_prompt_mark.bats test/dotfiles_sync_check.bats` — 10/10 pass
- `bin/ci_zsh_loading_test.sh` — exits 0
- `gitleaks protect --staged` — no leaks found

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none
