### PR TITLE
fix(zsh): defer carapace/vivid-colors (2 defers, ~85% cut)

### DIFF
--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -82,13 +82,18 @@ inline = 'if (( $+commands[kubectl] )); then zsh-defer _evalcache kubectl comple
 # LS_COLORS palette. vivid prints a raw value (not shell code), so
 # bin/vivid_ls_colors.sh (on PATH via ~/bin) wraps it in an export statement.
 # Guarded so a vivid-less box stays silent instead of re-caching every startup.
+# Only affects `ls`/`eza` colors, not the prompt, so defer it past the first
+# prompt like kubectl's completion (~20ms measured via zprof).
 [plugins.vivid-ls-colors]
-inline = 'if (( $+commands[vivid] )); then _evalcache vivid_ls_colors.sh; fi'
+inline = 'if (( $+commands[vivid] )); then zsh-defer _evalcache vivid_ls_colors.sh; fi'
 
 # Multi-shell completion engine. Bridges to zsh's native completions
 # (CARAPACE_BRIDGES in .zshrc) for commands it doesn't ship a spec for.
+# Even the cached copy's compdef registrations are the single biggest
+# _evalcache cost measured (~65ms via zprof) - defer past the first prompt,
+# same reasoning as kubectl's completion above.
 [plugins.carapace]
-inline = '_evalcache carapace _carapace zsh'
+inline = 'zsh-defer _evalcache carapace _carapace zsh'
 
 [templates]
 defer = "{{ hooks?.pre | nl }}{% for file in files %}zsh-defer source \"{{ file }}\"\n{% endfor %}{{ hooks?.post | nl }}"


### PR DESCRIPTION
## Summary

Follow-up to #93: after switching mise to shims, `zprof` showed carapace's completion registration (~65ms) and vivid's LS_COLORS export (~20ms) as the two largest remaining `_evalcache` costs before the first prompt. Neither is needed synchronously — defer both past the first prompt, same pattern already used for kubectl's completion.

## Changes

- `config/sheldon/plugins.toml`: prefix the `carapace` and `vivid-ls-colors` inline commands with `zsh-defer`.
- Added a one-line rationale comment above each, with the measured cost that motivated the defer.

## Verification

- `zprof` (full interactive startup, precmd hooks flushed): `_evalcache` total dropped 86ms -> ~25ms.
- `bin/ci_zsh_loading_test.sh` — exit 0; explicitly asserts `CARAPACE_COMP=_carapace` is registered (confirms the deferred completion still initializes before the probe runs).
- `bin/ci_tmux_loading_test.sh` — exit 0 (PASS).
- `bin/lint_shell.sh` — exit 0.
- `lefthook run pre-commit` / `gitleaks git --log-opts "origin/main..HEAD"` — no leaks found.
- Manually confirmed `LS_COLORS` and carapace completion (`_comps[carapace]`) are populated after flushing `$precmd_functions` once, so behavior is unchanged — just later.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Follow-up to #93