### PR TITLE
chore(git): add rebase.autosquash and autostash

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -53,6 +53,10 @@
   default = current
   autoSetupRemote = true
 
+[rebase]
+  autosquash = true
+  autostash = true
+
 [pull]
   ff = only
 


### PR DESCRIPTION
## Summary

Two small `.gitconfig` improvements that reduce day-to-day git friction. Independent of the existing settings, no risk. (`push.autoSetupRemote` was part of this PR originally but landed on main independently; dropped during rebase.)

## Changes

- `rebase.autosquash = true` — combined with `git commit --fixup`, fixup!/squash! commits are automatically reordered into place during `rebase -i`
- `rebase.autostash = true` — automatically stashes a dirty tree before a rebase and pops it afterwards, preventing rebases from aborting because of a forgotten manual stash

## Verification

- `.gitconfig` syntax check: parses cleanly with `git config --list --file .gitconfig`
- Rebased onto latest main; the diff is now only the `[rebase]` section (4 lines)
- No interference with the existing `push.default = current` / `pull.ff = only`

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYYfKNtTRM6bcJD3MQfPjG)_