### PR TITLE
chore(claude): add auto-mode user settings and mklink.sh symlink

### DIFF
--- a/bin/mklink.sh
+++ b/bin/mklink.sh
@@ -26,3 +26,6 @@ ln -sf "$BASE_DIR/.zshrc" ./
 ln -sf "$BASE_DIR/.irbrc" ./
 ln -sf "$BASE_DIR/.vimrc" ./
 ln -sf "$BASE_DIR/.aerospace.toml" ./
+
+mkdir -p "$HOME/.claude"
+ln -sf "$BASE_DIR/claude-user-settings.json" "$HOME/.claude/settings.json"

--- a/claude-user-settings.json
+++ b/claude-user-settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "defaultMode": "dontAsk"
+  }
+}


### PR DESCRIPTION
## Summary

Add `claude-user-settings.json` with `permissions.defaultMode = "dontAsk"` so Claude Code never prompts for tool approvals. `mklink.sh` now symlinks it to `~/.claude/settings.json`, making the preference durable across machines and sessions.

## Changes

- `claude-user-settings.json` — new file; `$schema`-validated user-level Claude Code settings with `defaultMode: "dontAsk"`
- `bin/mklink.sh` — create `~/.claude/` dir and symlink `claude-user-settings.json` → `~/.claude/settings.json`

## Verification

- `bin/lint_schema.sh claude-user-settings.json` → validated against `https://json.schemastore.org/claude-code-settings.json` ✓
- `bin/lint_shell.sh bin/mklink.sh` → no shellcheck warnings ✓
- `bin/lint_editorconfig.sh` → passes ✓

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYYfKNtTRM6bcJD3MQfPjG)_