### PR TITLE
test(ci): give tmux e2e first render a 30s budget

### DIFF
--- a/bin/ci_tmux_interactive_test.sh
+++ b/bin/ci_tmux_interactive_test.sh
@@ -46,8 +46,12 @@ tmux -L "$SOCK" set-option -w -t "$WIN_ID" automatic-rename off
 #    keystroke -> eval -> render path through a genuine terminal.
 # shellcheck disable=SC2016  # single-quoted on purpose: zsh in the pane must
 # evaluate $((6 * 7)), not this shell.
+# This first wait absorbs the whole interactive startup (compinit, evalcache
+# population on a cold runner), which can blow past the default 5s budget —
+# give it 30s. Later waits keep the default: once the prompt is up, each step
+# is a single keystroke round-trip.
 tmux -L "$SOCK" send-keys 'echo __E2E_READY__$((6 * 7))' Enter
-wait_for_pane "$SOCK" '__E2E_READY__42'
+wait_for_pane "$SOCK" '__E2E_READY__42' 300
 echo "== shell is live (echo rendered in pane) =="
 
 # 2) .zshrc actually took effect in a real tty (not just under `script`): an


### PR DESCRIPTION
## Summary

`ci_tmux_interactive_test.sh` is flaky on slow runners: its first `wait_for_pane` covers the entire interactive zsh startup (compinit, evalcache population) but only allows 5s, which is exactly where PR #95's `zsh_loading_test` job timed out while `main` at the same base SHA passed. Give that first wait a 30s budget.

## Changes

- `bin/ci_tmux_interactive_test.sh`: pass `300` tries (30s) to the first `wait_for_pane '__E2E_READY__42'`; later waits keep the 5s default since each is a single keystroke round-trip once the prompt is up.

## Verification

- Reproduced the CI failure locally (red): a zsh wrapper that delays interactive startup by 6s makes the unpatched test fail with the exact CI error `timed out waiting for: __E2E_READY__42`.
- With the fix, the same 6s-delayed startup passes (green), and a normal run still passes in ~1.6s.
- `./bin/lint_shell.sh` clean; full lefthook pre-commit suite (130 bats tests) passed.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Refs #95 (its `zsh_loading_test` failure was this flake; re-run went green with no code change).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KYUtdKvXLPpfnQsmsSgRc

---
_Generated by [Claude Code](https://claude.ai/code/session_016KYUtdKvXLPpfnQsmsSgRc)_