### PR TITLE
fix(zsh): keep /home/linuxbrew probes off macOS (autofs/AD lookups)

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -117,8 +117,13 @@ setw -g window-status-separator ""
 
 # '~/.tmux/plugins/tpm/tpm' returned 127 (on macOS, w/ tmux installed using brew)
 # https://github.com/tmux-plugins/tpm/blob/master/docs/tpm_not_working.md
-# Prepend the brew dirs instead of replacing PATH, so ~/.local/bin etc. survive.
-set-environment -g PATH "/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:$PATH"
+# Prepend the brew dir instead of replacing PATH, so ~/.local/bin etc. survive.
+# Split per platform: a nonexistent /home/linuxbrew entry in PATH makes every
+# command lookup stat /home, which on macOS is an autofs mount that can fire a
+# Directory Services (AD) lookup per stat. uname keeps the probe stat-free.
+if-shell 'test "$(uname)" = Linux' \
+  'set-environment -g PATH "/home/linuxbrew/.linuxbrew/bin:$PATH"' \
+  'set-environment -g PATH "/opt/homebrew/bin:$PATH"'
 run '~/.tmux/plugins/tpm/tpm'
 
 bind-key Space next-layout

--- a/.zshrc
+++ b/.zshrc
@@ -62,11 +62,23 @@ unset _zcompdump _zcompdump_stale
 typeset -U path # 重複したパスをPATHに登録しない
 typeset -U manpath
 typeset -xT SUDO_PATH sudo_path
+# /home/linuxbrew is added on Linux only: on macOS /home is an autofs mount,
+# so even stat()ing /home/* (which the (N-/) glob does) can fire a Directory
+# Services lookup — with corporate AD binding that is a network round trip per
+# shell. Same reason the inherited $path is scrubbed of it off-Linux (a tmux
+# server started before this fix may still inject it).
+_brew_bins=(/opt/homebrew/bin)
+if [[ $OSTYPE == linux* ]]; then
+  _brew_bins+=(/home/linuxbrew/.linuxbrew/bin)
+else
+  path=( ${path:#/home/linuxbrew/*} )
+fi
 path=(
   $HOME{,/.local,/.cargo,/.docker}/bin(N-/)
-  {/opt/homebrew,/home/linuxbrew/.linuxbrew}/bin(N-/)
+  ${^_brew_bins}(N-/)
   $path
 )
+unset _brew_bins
 manpath=(
   {$HOME/.local,/opt/local,/usr/local,/usr}/share/man(N-/)
   $manpath


### PR DESCRIPTION
## Summary

On macOS `/home` is an autofs mount: stat()ing `/home/*` can fire a Directory Services lookup, and on an AD-bound corporate machine that's a network round trip. Two spots probed `/home/linuxbrew` unconditionally — the likely root cause of the per-command lag observed on the work Mac (matches the on-site diagnosis).

## Changes

- `.zshrc`: add `/home/linuxbrew/.linuxbrew/bin` to `path` on Linux only; off-Linux, scrub any inherited `/home/linuxbrew/*` PATH entry (string filter, no stat) so a pre-fix tmux server can't re-inject it.
- `.tmux.conf`: the tpm PATH prepend is now split per platform via a stat-free `uname` probe instead of always injecting the linuxbrew dir.

## Verification

- `zsh -n`, lint_zsh, lint_editorconfig pass; tmux config parses (`tmux -L cfgcheck -f .tmux.conf start-server`).
- Verified both branches in `zsh -df`: Linux keeps the linuxbrew dir; the macOS path scrub removes an inherited entry without stat()ing it.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Follow-up to #90/#91/#93 (zsh performance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LT66RqibT9SCEnL1vSxRTb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LT66RqibT9SCEnL1vSxRTb)_