### PR TITLE
feat(tmux): QoL options, indicators, fzf session switcher, load-time budget

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -60,6 +60,13 @@ bind-key r source-file ~/.tmux.conf \; display-message "config reloaded"
 bind-key g display-popup -E -w 90% -h 85% -d "#{pane_current_path}" lazygit
 bind-key t display-popup -E -w 80% -h 75% -d "#{pane_current_path}"
 
+# f = fzf switcher across every window of every session, with a live pane
+# preview (replaces the default find-window)
+bind-key f display-popup -E -w 90% -h 70% 'tmux list-windows -a -F "##S:##I  ##W" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
+
+# toggle the status bar (handy for screen sharing)
+bind-key b set-option status
+
 
 set -g set-titles on
 setw -g automatic-rename on

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -2,7 +2,10 @@ set-option -g prefix C-t
 bind C-t send-prefix
 unbind-key C-b
 set-option -g base-index 1
+setw -g pane-base-index 1
 set-option -g renumber-windows on
+# killing the last window of a session jumps to another session instead of detaching
+set-option -g detach-on-destroy off
 
 setw -g mode-keys vi
 unbind-key -T copy-mode-vi v
@@ -46,6 +49,12 @@ bind-key -n M-Down switch-client -n
 
 # pane move: m でmark → M で移動
 bind-key M join-pane -s .
+
+bind-key r source-file ~/.tmux.conf \; display-message "config reloaded"
+
+# popups: g = lazygit, t = throwaway shell (replaces the default clock-mode)
+bind-key g display-popup -E -w 90% -h 85% -d "#{pane_current_path}" lazygit
+bind-key t display-popup -E -w 80% -h 75% -d "#{pane_current_path}"
 
 
 set -g set-titles on

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -38,6 +38,10 @@ bind-key -n M-h select-pane -L
 bind-key -n M-j select-pane -D
 bind-key -n M-k select-pane -U
 bind-key -n M-l select-pane -R
+bind-key -n M-z resize-pane -Z
+
+# type into every pane of the window at once (status-right shows ⚠ SYNC while on)
+bind-key e setw synchronize-panes \; display-message "synchronize-panes #{?pane_synchronized,on,off}"
 
 # command+option+←/→でwindow移動
 bind-key -n M-Left previous-window
@@ -73,6 +77,10 @@ set -as terminal-features '*:hyperlinks'
 set -as terminal-features '*:clipboard'
 set -as terminal-overrides ',xterm-256color:RGB'
 set -g set-clipboard on
+# pass modified keys (Shift+Enter etc.) through to apps when the outer
+# terminal supports CSI u / modifyOtherKeys (Ghostty does)
+set -s extended-keys on
+set -as terminal-features 'xterm*:extkeys'
 
 set -g @tpm_plugins ' \
   tmux-plugins/tpm \
@@ -90,6 +98,7 @@ set -g @tpm_plugins ' \
 set -g @continuum-restore 'on'
 set -g @continuum-save-interval '15'
 set -g @resurrect-capture-pane-contents 'on'
+set -g @resurrect-strategy-nvim 'session'
 
 set -g @extrakto_copy_key "tab"
 set -g @extrakto_insert_key "enter"
@@ -109,8 +118,8 @@ set -g message-style "bg=#073642,fg=#2aa198"
 set -g message-command-style "bg=#073642,fg=#2aa198"
 set -g status-left-length 50
 set -g status-right-length 100
-set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #(tmux list-sessions -F '##{?session_attached,#[fg=#fdf6e3]#[bg=#268bd2]●,#[fg=#002b36]#[bg=#268bd2]•}' | tr -d '\n') #{session_name} #[fg=#268bd2,bg=#073642,nobold] "
-set -g status-right "#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
+set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #(tmux list-sessions -F '##{?session_attached,#[fg=#fdf6e3]#[bg=#268bd2]●,#[fg=#002b36]#[bg=#268bd2]•}' | tr -d '\n') #{?client_prefix,⌨ ,}#{session_name} #[fg=#268bd2,bg=#073642,nobold] "
+set -g status-right "#{?pane_synchronized,#[fg=#dc322f bg=#073642 bold]⚠ SYNC #[nobold],}#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
 # Claude Code state indicator: bin/claude_tmux_indicator.sh tags panes with
 # @claude_state (waiting=red #dc322f, done=yellow #b58900, red wins); the
 # hooks below recompute the window color when panes move or die. Deferred via
@@ -120,8 +129,8 @@ set -g status-right "#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] �
 set -g @claude_win_color '#{?#{m:*waiting*,#{P:#{@claude_state}}},#dc322f,#{?#{m:*done*,#{P:#{@claude_state}}},#b58900,}}'
 set-hook -ga window-layout-changed 'run-shell -b "tmux set-option -wF -t \"#{window_id}\" @claude_color \"##{E:@claude_win_color}\""'
 set-hook -ga window-linked 'run-shell -b "tmux set-option -wF -t \"#{window_id}\" @claude_color \"##{E:@claude_win_color}\""'
-setw -g window-status-format "#[fg=#{?window_bell_flag,#dc322f,#{?#{@claude_color},#{@claude_color},#586e75}},bg=#073642]#{?#{@claude_color},#[bold],} #I:#W#{?#{@claude_color}, ✳,} "
-setw -g window-status-current-format "#[fg=#073642,bg=#{?#{@claude_color},#{@claude_color},#2aa198}]#[fg=#002b36,bg=#{?#{@claude_color},#{@claude_color},#2aa198},bold] #I:#W#{?#{@claude_color}, ✳,} #[fg=#{?#{@claude_color},#{@claude_color},#2aa198},bg=#073642]"
+setw -g window-status-format "#[fg=#{?window_bell_flag,#dc322f,#{?#{@claude_color},#{@claude_color},#586e75}},bg=#073642]#{?#{@claude_color},#[bold],} #I:#W#{?window_zoomed_flag, 🔍,}#{?#{@claude_color}, ✳,} "
+setw -g window-status-current-format "#[fg=#073642,bg=#{?#{@claude_color},#{@claude_color},#2aa198}]#[fg=#002b36,bg=#{?#{@claude_color},#{@claude_color},#2aa198},bold] #I:#W#{?window_zoomed_flag, 🔍,}#{?#{@claude_color}, ✳,} #[fg=#{?#{@claude_color},#{@claude_color},#2aa198},bg=#073642]"
 setw -g window-status-separator ""
 
 # '~/.tmux/plugins/tpm/tpm' returned 127 (on macOS, w/ tmux installed using brew)
@@ -143,6 +152,8 @@ set-option -g pane-border-format " ###{pane_index}: #{?#{==:#{pane_title},#{host
 set-option -g pane-border-lines heavy
 set-option -g pane-border-style "fg=#2c4a52"
 set-option -g pane-active-border-style "fg=#2aa198"
+# copy-mode selection color (all versions; on 3.6+ copy-mode-selection-style below wins)
+set -g mode-style "fg=#002b36,bg=#2aa198"
 # tmux 3.6+ のみ適用（古い tmux では unknown option を避けるためスキップ）
 if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 6 ]; }' \
   'set -g copy-mode-selection-style "bg=#2aa198,fg=#002b36"'

--- a/bin/ci_tmux_loading_test.sh
+++ b/bin/ci_tmux_loading_test.sh
@@ -23,10 +23,20 @@ trap cleanup EXIT
 # Bare server first, then load the real config so parse errors surface.
 tmux -L "$SOCK" new-session -d -x 200 -y 50 2>/dev/null || die "failed to start tmux server"
 
+# Load-time budget. Generous vs the ~100ms it actually takes, so only a real
+# regression (e.g. a load-time #()/run-shell sneaking in) trips it, not runner
+# noise. Overridable for tuning/testing via TMUX_LOAD_BUDGET_MS.
+LOAD_BUDGET_MS="${TMUX_LOAD_BUDGET_MS:-300}"
+# macOS `date` lacks %N, so use perl for portable millisecond timestamps.
+need perl
+now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time()*1000'; }
+
+start_ms="$(now_ms)"
 set +e
 tmux -L "$SOCK" source-file "$CONF" 2>"$err_log"
 rc=$?
 set -e
+end_ms="$(now_ms)"
 
 if [ "$rc" -ne 0 ]; then
   echo "---- source-file exit $rc ----"; cat "$err_log"
@@ -38,6 +48,18 @@ if grep -qiE 'unknown option|invalid option|unknown command|ambiguous command|[^
 fi
 [ -s "$err_log" ] && { echo "-- note: non-fatal stderr from load --"; cat "$err_log"; }
 echo "== loaded without config errors =="
+
+load_ms=$((end_ms - start_ms))
+echo "== load time: ${load_ms}ms (budget: ${LOAD_BUDGET_MS}ms) =="
+if [ "$load_ms" -gt "$LOAD_BUDGET_MS" ]; then
+  echo "---- load-time budget exceeded ----"
+  echo "NOTE: timing on shared CI runners fluctuates. If this budget check is"
+  echo "the ONLY failure, re-run the job once before investigating — treat a"
+  echo "single overrun as flaky. Only a failure that reproduces on re-run is"
+  echo "a real regression; then look for load-time #()/run-shell additions in"
+  echo "recent .tmux.conf changes."
+  die ".tmux.conf took ${load_ms}ms to load (budget: ${LOAD_BUDGET_MS}ms)"
+fi
 
 echo "== tmux $(tmux -V | sed 's/tmux //') guard: version check skipped (show-options scope varies by build) =="
 echo "PASS"

--- a/bin/ci_tmux_loading_test.sh
+++ b/bin/ci_tmux_loading_test.sh
@@ -23,10 +23,11 @@ trap cleanup EXIT
 # Bare server first, then load the real config so parse errors surface.
 tmux -L "$SOCK" new-session -d -x 200 -y 50 2>/dev/null || die "failed to start tmux server"
 
-# Load-time budget. Generous vs the ~100ms it actually takes, so only a real
-# regression (e.g. a load-time #()/run-shell sneaking in) trips it, not runner
-# noise. Overridable for tuning/testing via TMUX_LOAD_BUDGET_MS.
-LOAD_BUDGET_MS="${TMUX_LOAD_BUDGET_MS:-300}"
+# Load-time budget. Observed: ~100ms on a local Linux box, ~510ms on a shared
+# GitHub runner (slower CPU + tpm/plugin sourcing), so 1000ms only trips on a
+# real regression (e.g. a load-time #()/run-shell or network call sneaking in,
+# which costs seconds). Overridable for tuning/testing via TMUX_LOAD_BUDGET_MS.
+LOAD_BUDGET_MS="${TMUX_LOAD_BUDGET_MS:-1000}"
 # macOS `date` lacks %N, so use perl for portable millisecond timestamps.
 need perl
 now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time()*1000'; }


### PR DESCRIPTION
## Summary

A batch of tmux quality-of-life improvements: saner session/pane defaults, popup workflows (lazygit, scratch shell, cross-session fzf switcher), status-bar indicators for zoom/prefix/synchronize-panes, better key/copy handling, and a load-time budget in the CI loading test so config regressions get caught.

## Changes

- `.tmux.conf` — QoL options: `detach-on-destroy off` (killing a session's last window switches to another session instead of detaching), `pane-base-index 1` (match `base-index`), `prefix+r` config reload
- `.tmux.conf` — popups: `prefix+g` lazygit, `prefix+t` throwaway shell (both in the current pane's directory; `prefix+t` replaces clock-mode)
- `.tmux.conf` — `prefix+f`: fzf popup listing every window of every session with a live `capture-pane` preview; selecting switches session+window (replaces `find-window`)
- `.tmux.conf` — indicators: `M-z` prefix-less zoom toggle with 🔍 in the window status, ⌨ in status-left while the prefix is active, `prefix+e` synchronize-panes toggle with a red `⚠ SYNC` warning in status-right, `prefix+b` status-bar visibility toggle
- `.tmux.conf` — key/copy handling: `extended-keys on` + `xterm*:extkeys` (modified keys like Shift+Enter pass through under Ghostty), `mode-style` so copy-mode selection is Solarized on tmux &lt;3.6 too, `@resurrect-strategy-nvim 'session'`
- `bin/ci_tmux_loading_test.sh` — measure `source-file` duration (perl Time::HiRes; macOS `date` lacks `%N`) and fail over `TMUX_LOAD_BUDGET_MS` (default 1000ms); the failure message tells the reader to re-run once before investigating since shared-runner timing fluctuates. Initially shipped at 300ms calibrated on a local run (~100ms), but the GitHub runner needs ~510ms, so the first CI run tripped it — raised to 1000ms, which still catches real regressions (load-time `#()`/`run-shell`/network calls cost seconds)

## Verification

- `./bin/ci_tmux_loading_test.sh` PASS (tpm installed first, as after `mkworld`)
- Throwaway tmux servers: verified all new options took effect (`detach-on-destroy`, `pane-base-index`, `extended-keys`, `mode-style`, `@resurrect-strategy-nvim`) and all new bindings registered (`prefix` r/g/t/f/e/b, root `M-z`)
- Exercised behavior end-to-end where possible headless: sync toggle renders `⚠ SYNC` in status-right, zoom sets `window_zoomed_flag` and renders 🔍, switcher pipeline extracts the right `session:window` target across multiple sessions and `capture-pane` preview works, `##S`/`$sel` escaping validated through the same format-expansion path via `run-shell`
- Load-time budget TDD red/green: `TMUX_LOAD_BUDGET_MS=1` fails with the re-run hint (exit 1); default budget passes at ~103ms locally. Benchmarked config load main vs branch: 106ms vs 102ms avg (5 runs each), no regression. The budget's failure path was also exercised for real by CI (511ms > 300ms on the shared runner), which is what prompted the recalibration to 1000ms
- `./bin/lint_shell.sh` clean; lefthook pre-commit/commit-msg hooks passed on every commit

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN