### PR TITLE
fix(tmux): unescape formats in the prefix+f switcher popup command

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -62,7 +62,7 @@ bind-key t display-popup -E -w 80% -h 75% -d "#{pane_current_path}"
 
 # f = fzf switcher across every window of every session, with a live pane
 # preview (replaces the default find-window)
-bind-key f display-popup -E -w 90% -h 70% 'tmux list-windows -a -F "##S:##I  ##W" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
+bind-key f display-popup -E -w 90% -h 70% 'tmux list-windows -a -F "#S:#I  #W" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
 
 # toggle the status bar (handy for screen sharing)
 bind-key b set-option status


### PR DESCRIPTION
## Summary

Follow-up to #101: the `prefix+f` cross-session switcher rendered every fzf line as the literal string `#S:#I  #W` instead of real session/window names. `display-popup` does not format-expand its shell-command (unlike `run-shell`, which the original verification wrongly relied on), so the escaped `##S:##I  ##W` reached `list-windows -F` verbatim and `##` collapsed to a literal `#`.

## Changes

- `.tmux.conf` — write the switcher's `list-windows -F` formats plainly (`#S:#I  #W`); `list-windows` itself expands them. One-line change to the `prefix+f` binding.

## Verification

- Reproduced the root cause empirically in a nested tmux (outer server hosting an attached inner client): a `display-popup -E "echo X#SX > file"` writes `X#SX`, proving popup shell-commands are not format-expanded
- Ran the fixed command through an actual `display-popup` against an inner server with two sessions/three windows: output is the real list (`alpha:0  zsh`, `beta:0  zsh`, `beta:1  logs`)
- `./bin/ci_tmux_loading_test.sh` PASS; lefthook pre-commit/commit-msg hooks passed

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN

---
_Generated by [Claude Code](https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN)_