### PR TITLE
ci(zsh): record zsh-bench startup results on main and manual dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,16 @@ jobs:
       - name: Load to test .zshrc
         run: ./bin/ci_zsh_loading_test.sh
 
+      # ~1 min per run, so not on every branch push: record on main (one data
+      # point per merged commit, comparable over time) and on manual dispatch.
+      # Record-only — a slow-startup budget that fails the build is a separate,
+      # future check.
       - name: Benchmark zsh startup (zsh-bench -> job summary + artifact)
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         run: ./bin/ci_zsh_bench.sh
 
       - name: Upload zsh-bench results
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zsh-bench-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,15 @@ jobs:
       - name: Load to test .zshrc
         run: ./bin/ci_zsh_loading_test.sh
 
+      - name: Benchmark zsh startup (zsh-bench -> job summary + artifact)
+        run: ./bin/ci_zsh_bench.sh
+
+      - name: Upload zsh-bench results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zsh-bench-results
+          path: ${{ runner.temp }}/zsh-bench.txt
+
       - name: Load to test .tmux.conf
         run: ./bin/ci_tmux_loading_test.sh
 

--- a/bin/ci_zsh_bench.sh
+++ b/bin/ci_zsh_bench.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Benchmark interactive zsh startup with zsh-bench (romkatv/zsh-bench) and keep
+# the numbers around instead of letting them scroll away in the job log:
+#   - appended to $GITHUB_STEP_SUMMARY as a table (the run's Summary page)
+#   - written to $RUNNER_TEMP/zsh-bench.txt for the workflow's artifact upload
+# Measures the login shell of the current user, i.e. the dotfiles that
+# bin/mkworld.sh symlinked into $HOME during the CI prepare phase. Record-only:
+# it never fails the build over a slow number.
+
+set -euo pipefail
+
+# Same startup toggles as ci_zsh_loading_test.sh: keep the sync/brew reminders
+# (network + noise) out of the measured startup.
+export DOTFILES_NO_SYNC_CHECK=1
+export DOTFILES_NO_BREW_CHECK=1
+export TERM="xterm-256color"
+
+# zsh-bench needs zsh >= 5.8 on PATH to run itself; in CI that's the brew zsh
+# from Brewfile.basic - the same binary the loading test exercises.
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+
+# Pinned like GitHub Actions `uses:`: a full commit SHA, not a branch.
+ZSH_BENCH_REPO="https://github.com/romkatv/zsh-bench"
+ZSH_BENCH_REV="28b1b1bc888159f0a2cf50f9d29381758341aba1"
+
+bench_dir="$(mktemp -d)"
+trap 'rm -rf "$bench_dir"' EXIT
+git init --quiet "$bench_dir"
+git -C "$bench_dir" fetch --quiet --depth 1 "$ZSH_BENCH_REPO" "$ZSH_BENCH_REV"
+git -C "$bench_dir" checkout --quiet FETCH_HEAD
+
+out_file="${RUNNER_TEMP:-$(mktemp -d)}/zsh-bench.txt"
+"$bench_dir/zsh-bench" --iters "${ZSH_BENCH_ITERS:-16}" | tee "$out_file"
+
+# The key=value lines are the machine-readable half of the output; render them
+# as a table on the run's Summary page so results are visible without digging
+# through logs.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## zsh-bench (login shell startup)"
+    echo ""
+    echo "| metric | value |"
+    echo "| --- | --- |"
+    grep -E '^[a-z_]+=' "$out_file" | sed -E 's/^([a-z_]+)=(.*)$/| \1 | \2 |/'
+  } >>"$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Summary

Record zsh startup benchmark results in CI so perf work has numbers to compare against. Runs [romkatv/zsh-bench](https://github.com/romkatv/zsh-bench) against the dotfiles symlinked into `$HOME`, renders the metrics as a table on the run's Summary page, and uploads the raw output as a workflow artifact (default 90-day retention).

## Changes

- Add `bin/ci_zsh_bench.sh`: fetch zsh-bench pinned to a commit SHA, benchmark the login shell (16 iterations, `ZSH_BENCH_ITERS` to override), write a metric table to `$GITHUB_STEP_SUMMARY` and the raw `key=value` output to `$RUNNER_TEMP/zsh-bench.txt`. Record-only — it never fails the build over a slow number (a startup-time budget check is planned separately).
- Wire it into the `zsh_loading_test` job after the `.zshrc` load test, plus an `actions/upload-artifact` step (pinned to a SHA) that keeps `zsh-bench.txt` per run.
- Gate both steps on `main` pushes and `workflow_dispatch` — the bench adds ~1 min, too heavy for every branch push. One data point per merged commit keeps the history comparable over time.

## Verification

- Ran `./bin/ci_zsh_bench.sh` locally (Linux, zsh 5.9) with `GITHUB_STEP_SUMMARY`/`RUNNER_TEMP` set: zsh-bench completed and reported all metrics (`first_prompt_lag_ms`, `command_lag_ms`, `exit_time_ms`, …), the summary table rendered correctly, and `zsh-bench.txt` was written to `$RUNNER_TEMP`.
- Timed 4 iterations at ~11 s, so the default 16 stays under ~1 min in CI.
- `./bin/lint_shell.sh`, `./bin/lint_bash.sh`, `./bin/lint_actions.sh` (ratchet pin check), `./bin/lint_config.sh`, `./bin/lint_editorconfig.sh` all pass.
- A `workflow_dispatch` run on this branch will exercise the gated steps for real (branch pushes skip them by design).

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w4KzGPvys7U8gvbBpySR7

---
_Generated by [Claude Code](https://claude.ai/code/session_013w4KzGPvys7U8gvbBpySR7)_