### PR TITLE
fix(ci): replace zsh-bench with a deadlock-proof startup timing loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,16 +131,16 @@ jobs:
       # point per merged commit, comparable over time) and on manual dispatch.
       # Record-only — a slow-startup budget that fails the build is a separate,
       # future check.
-      - name: Benchmark zsh startup (zsh-bench -> job summary + artifact)
+      - name: Benchmark zsh startup (timing loop -> job summary + artifact)
         if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         run: ./bin/ci_zsh_bench.sh
 
-      - name: Upload zsh-bench results
+      - name: Upload zsh startup bench results
         if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: zsh-bench-results
-          path: ${{ runner.temp }}/zsh-bench.txt
+          name: zsh-startup-bench
+          path: ${{ runner.temp }}/zsh-startup-bench.txt
 
       - name: Load to test .tmux.conf
         run: ./bin/ci_tmux_loading_test.sh

--- a/bin/ci_zsh_bench.sh
+++ b/bin/ci_zsh_bench.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
-# Benchmark interactive zsh startup with zsh-bench (romkatv/zsh-bench) and keep
-# the numbers around instead of letting them scroll away in the job log:
+# Benchmark interactive zsh startup in CI and keep the numbers around instead
+# of letting them scroll away in the job log:
 #   - appended to $GITHUB_STEP_SUMMARY as a table (the run's Summary page)
-#   - written to $RUNNER_TEMP/zsh-bench.txt for the workflow's artifact upload
-# Measures the login shell of the current user, i.e. the dotfiles that
-# bin/mkworld.sh symlinked into $HOME during the CI prepare phase. Record-only:
-# it never fails the build over a slow number.
+#   - written to $RUNNER_TEMP/zsh-startup-bench.txt for the artifact upload
+#
+# The metric is deliberately simple: wall-clock time of `zsh -lic exit` (parse
+# the config, run compinit/sheldon/evalcache, become ready for a command),
+# repeated N times, reported as min/mean/max. An earlier version drove
+# romkatv/zsh-bench here, but its zle-level protocol deadlocks against this
+# config (`setopt ignore_eof` blocks its stdin-EOF exit on a completion-list
+# prompt, and its instrumented typing never completed against the custom
+# space/enter widgets) - see PR #107. A plain timing loop cannot hang and is
+# what a startup-time budget check would threshold anyway. Measures the
+# dotfiles that bin/mkworld.sh symlinked into $HOME during the CI prepare
+# phase. Record-only: it never fails the build over a slow number.
 
 set -euo pipefail
+
+die() {
+  echo "CI error: $*" >&2
+  exit 1
+}
 
 # Same startup toggles as ci_zsh_loading_test.sh: keep the sync/brew reminders
 # (network + noise) out of the measured startup.
@@ -15,31 +28,58 @@ export DOTFILES_NO_SYNC_CHECK=1
 export DOTFILES_NO_BREW_CHECK=1
 export TERM="xterm-256color"
 
-# zsh-bench needs zsh >= 5.8 on PATH to run itself; in CI that's the brew zsh
-# from Brewfile.basic - the same binary the loading test exercises.
+# In CI the shell under test is the brew zsh from Brewfile.basic - the same
+# binary the loading test exercises.
 if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
+command -v zsh >/dev/null || die "zsh not found"
 
-# Pinned like GitHub Actions `uses:`: a full commit SHA, not a branch.
-ZSH_BENCH_REPO="https://github.com/romkatv/zsh-bench"
-ZSH_BENCH_REV="28b1b1bc888159f0a2cf50f9d29381758341aba1"
+# One timed startup. CI= (empty) for the same reason ci_zsh_loading_test.sh
+# runs every probe with it: CI=true switches .zshrc into strict mode
+# (err_exit), which is not how an interactive shell runs for real. The
+# per-run timeout turns any regression into a hang into a fast, attributable
+# step failure instead of a job stuck until the runner's 6h limit.
+run_once() {
+  local t0 t1
+  t0=$(date +%s%N)
+  timeout 60 env CI= zsh -lic exit </dev/null >/dev/null 2>&1 \
+    || die "interactive zsh startup failed or timed out (rc=$?)"
+  t1=$(date +%s%N)
+  echo $(((t1 - t0) / 1000000))
+}
 
-bench_dir="$(mktemp -d)"
-trap 'rm -rf "$bench_dir"' EXIT
-git init --quiet "$bench_dir"
-git -C "$bench_dir" fetch --quiet --depth 1 "$ZSH_BENCH_REPO" "$ZSH_BENCH_REV"
-git -C "$bench_dir" checkout --quiet FETCH_HEAD
+iters="${ZSH_BENCH_ITERS:-10}"
+run_once >/dev/null # warm-up: compdump/eval caches, page cache
 
-out_file="${RUNNER_TEMP:-$(mktemp -d)}/zsh-bench.txt"
-"$bench_dir/zsh-bench" --iters "${ZSH_BENCH_ITERS:-16}" | tee "$out_file"
+samples=()
+for _ in $(seq "$iters"); do
+  samples+=("$(run_once)")
+done
 
-# The key=value lines are the machine-readable half of the output; render them
-# as a table on the run's Summary page so results are visible without digging
-# through logs.
+out_file="${RUNNER_TEMP:-$(mktemp -d)}/zsh-startup-bench.txt"
+{
+  echo "zsh_version=$(zsh --version | awk '{print $2}')"
+  echo "iters=$iters"
+  printf '%s\n' "${samples[@]}" | sort -n | awk '
+    { v[NR] = $1; sum += $1 }
+    END {
+      printf "startup_min_ms=%d\n", v[1]
+      printf "startup_mean_ms=%d\n", sum / NR
+      printf "startup_max_ms=%d\n", v[NR]
+    }'
+  echo "samples_ms=$(
+    IFS=,
+    echo "${samples[*]}"
+  )"
+} | tee "$out_file"
+
+# The key=value lines are the machine-readable output; render them as a table
+# on the run's Summary page so results are visible without digging through
+# logs.
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
-    echo "## zsh-bench (login shell startup)"
+    echo "## zsh startup bench (zsh -lic exit)"
     echo ""
     echo "| metric | value |"
     echo "| --- | --- |"


### PR DESCRIPTION
## Summary

The zsh-bench CI step (#104) never finished in CI. Two of its deadlocks were root-caused and fixed, but its zle-level instrumentation still never completed against this config's custom widgets — so this PR replaces the measurement with a plain timing loop (`env CI= zsh -lic exit` × N, min/mean/max) that cannot hang, finishes in seconds, and keeps the retention machinery (job-summary table + artifact) unchanged.

## Changes

- Rewrite `bin/ci_zsh_bench.sh`: N (default 10) timed runs of `env CI= zsh -lic exit` after one warm-up, reporting `startup_{min,mean,max}_ms` plus raw `samples_ms` as `key=value` lines → rendered as a table on the run's Summary page and written to `$RUNNER_TEMP/zsh-startup-bench.txt`. Each run is capped by `timeout 60`, so a future config regression into a hang fails the step fast instead of stalling the job for 6 h. Record-only, as before.
- `ci.yml`: artifact renamed to `zsh-startup-bench`; gating unchanged (main pushes + `workflow_dispatch` only).

## Why not zsh-bench

Root-caused via an on-runner debug pass; each of these alone deadlocked it:

1. `CI=true` switches `.zshrc` into strict mode (`err_exit`) — the first failing command inside the benched interactive shell kills it and zsh-bench blocks on its sync FIFO (fixed with `env CI=`, reproduced red/green locally).
2. `.zshrc`'s `setopt ignore_eof` — zsh-bench closes the benched shell's stdin and expects an EOF exit; zle instead blocked forever on ^D's `delete-char-or-list` ("do you wish to see all 5142 possibilities?", captured verbatim in the debug run). Fixed with a `ZDOTDIR` wrapper, reproduced red/green locally.
3. Even with both fixes, its instrumented-typing protocol never completed against the custom space/enter widgets (abbr), autosuggestions, and carapace's 5000+ compdefs: 2 iterations could not finish within 120 s while `ci_zsh_loading_test.sh` drives the same shell in ~2 s. At that point zsh-bench is a poor fit for this config, and a plain wall-clock number is what a startup-time budget check would threshold anyway.

## Verification

- Local run of the rewritten script under `CI=true` with a fake `$HOME` loading the full sheldon plugin stack: completes in seconds, prints `startup_min/mean/max_ms` + samples, writes the summary table and the artifact file.
- `./bin/lint_shell.sh`, `./bin/lint_actions.sh`, `./bin/lint_editorconfig.sh` and the full pre-commit hook suite pass.
- A `workflow_dispatch` run on this branch exercises the bench end-to-end in CI (branch pushes skip it by design); will mark ready for review once green.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w4KzGPvys7U8gvbBpySR7