### PR TITLE
feat(tmux): adopt 3.6/3.7 features behind version guards

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -162,8 +162,16 @@ set-option -g pane-active-border-style "fg=#2aa198"
 # copy-mode selection color (all versions; on 3.6+ copy-mode-selection-style below wins)
 set -g mode-style "fg=#002b36,bg=#2aa198"
 # tmux 3.6+ のみ適用（古い tmux では unknown option を避けるためスキップ）
+# menu-*: Solarized colors for menus (tmux-menus etc.); prompt-cursor-*: theme
+# colored bar cursor at the command prompt
 if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 6 ]; }' \
-  'set -g copy-mode-selection-style "bg=#2aa198,fg=#002b36"'
+  'set -g copy-mode-selection-style "bg=#2aa198,fg=#002b36"; set -g menu-style "bg=#073642,fg=#839496"; set -g menu-border-style "fg=#2aa198"; set -g prompt-cursor-colour "#2aa198"; set -g prompt-cursor-style bar'
+
+# tmux 3.7+ only: copy-mode-line-numbers hybrid = absolute number on the
+# cursor line, relative elsewhere (for vi-style 5k/3j jumps); get-clipboard
+# both = also relay pane clipboard requests to the outer terminal (OSC52 read)
+if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 7 ]; }' \
+  'set -g copy-mode-line-numbers hybrid; set -g get-clipboard both'
 set-option -g window-style "bg=default"
 set-option -g window-active-style "bg=default"
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -59,6 +59,11 @@ bind-key r source-file ~/.tmux.conf \; display-message "config reloaded"
 # popups: g = lazygit, t = throwaway shell (replaces the default clock-mode)
 bind-key g display-popup -E -w 90% -h 85% -d "#{pane_current_path}" lazygit
 bind-key t display-popup -E -w 80% -h 75% -d "#{pane_current_path}"
+# tmux 3.7+: rebind g/t to floating panes instead of popups. Popups are modal
+# — prefix bindings (extrakto, copy mode) don't work inside them — while a
+# floating pane is a regular pane; move/resize it with the mouse
+if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 7 ]; }' \
+  'bind-key g new-pane -c "#{pane_current_path}" lazygit; bind-key t new-pane -c "#{pane_current_path}"'
 
 # f = fzf switcher across every window of every session, with a live pane
 # preview (replaces the default find-window)


### PR DESCRIPTION
## Summary

Adopt tmux 3.6/3.7 features behind version guards (same pattern as the existing 3.6+ guard, so tmux ≤3.5 keeps working unchanged): copy-mode line numbers, clipboard read relay, Solarized menus/prompt cursor, and floating panes for the lazygit/scratch bindings — popups are modal so prefix bindings like extrakto were dead inside them.

## Changes

- `.tmux.conf` (3.6+ guard, extended): `menu-style`/`menu-border-style` Solarized (tmux-menus was still on default colors); `prompt-cursor-colour #2aa198` + `prompt-cursor-style bar` for a theme-colored command-prompt cursor
- `.tmux.conf` (3.7+ guard, new): `copy-mode-line-numbers hybrid` (absolute on the cursor line, relative elsewhere — for vi-style `5k`/`3j` jumps); `get-clipboard both` (relay pane clipboard requests to the outer terminal — the OSC52 read direction, pairing with the existing `set-clipboard` write direction)
- `.tmux.conf` (3.7+ guard, new): rebind `prefix+g` (lazygit) and `prefix+t` (scratch shell) from `display-popup` to floating panes (`new-pane`). Floating panes are regular panes, so extrakto, copy mode, and every prefix binding work inside them, and they can be moved/resized with the mouse. tmux ≤3.6 keeps the popup behavior

## Verification

- Option names and values verified against tmux 3.7 `options-table.c` and CHANGES (verbatim); floating-pane behavior (`new-pane` command, mouse-only move/resize) confirmed from `cmd-split-window.c`/`cmd-resize-pane.c` and CHANGES for 3.7
- 3.7+ guard logic tested under `sh` against version strings 3.4/3.6/3.7a/4.0 → skip/skip/apply/apply
- On local tmux 3.4: `./bin/ci_tmux_loading_test.sh` PASS, and `prefix+g`/`prefix+t` verified to keep their popup bindings (guard correctly skipped)
- The apply path runs on CI's brew tmux 3.7: the loading test fails on any unknown option/value, so a wrong 3.7 option name cannot land green
- lefthook pre-commit/commit-msg hooks passed on every commit

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN

---
_Generated by [Claude Code](https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN)_