### PR TITLE
fix(tmux): stop status-left jitter from the prefix indicator

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -125,7 +125,7 @@ set -g message-style "bg=#073642,fg=#2aa198"
 set -g message-command-style "bg=#073642,fg=#2aa198"
 set -g status-left-length 50
 set -g status-right-length 100
-set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #(tmux list-sessions -F '##{?session_attached,#[fg=#fdf6e3]#[bg=#268bd2]●,#[fg=#002b36]#[bg=#268bd2]•}' | tr -d '\n') #{?client_prefix,⌨ ,}#{session_name} #[fg=#268bd2,bg=#073642,nobold] "
+set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #(tmux list-sessions -F '##{?session_attached,#[fg=#fdf6e3]#[bg=#268bd2]●,#[fg=#002b36]#[bg=#268bd2]•}' | tr -d '\n') #{?client_prefix,#[bg=#b58900],}#{session_name}#[bg=#268bd2] #[fg=#268bd2,bg=#073642,nobold] "
 set -g status-right "#{?pane_synchronized,#[fg=#dc322f bg=#073642 bold]⚠ SYNC #[nobold],}#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
 # Claude Code state indicator: bin/claude_tmux_indicator.sh tags panes with
 # @claude_state (waiting=red #dc322f, done=yellow #b58900, red wins); the


### PR DESCRIPTION
## Summary

The ⌨ glyph inserted before the session name while the prefix is active (from #101) changed the status-left width, so rapid prefix use (`C-t n` repeatedly) made the whole status bar wobble. Indicate the prefix by color instead: the session name's background switches blue → yellow (#b58900) while the prefix is active — same information, constant width.

## Changes

- `.tmux.conf` — replace the width-changing `#{?client_prefix,⌨ ,}` glyph in `status-left` with a style-only conditional that swaps the session name's background color; explicitly reset the background after the name so the powerline segment stays intact

## Verification

- `./bin/ci_tmux_loading_test.sh` PASS
- Width invariance is by construction: the conditional now toggles only an inline `#[bg=…]` style block, adding no characters
- lefthook pre-commit/commit-msg hooks passed

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN

---
_Generated by [Claude Code](https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN)_