### PR TITLE
docs(keybindings): sync new tmux binds and point agents at KEYBINDINGS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ truth, so the two never diverge.
   `ci_zsh_loading_test.sh` / `ci_tmux_loading_test.sh`.
 - `config/` — XDG configs symlinked to `~/.config` (nvim, ghostty, starship, …).
 - Root dotfiles — `.zshrc`, `.tmux.conf`, `.vimrc`, `.gitconfig`, … into `$HOME`.
+- `KEYBINDINGS.md` — layered keybinding reference (macOS → AeroSpace → Ghostty →
+  tmux → zsh; upper layers intercept first). When you add, remove, or rebind a
+  key anywhere (`.tmux.conf`, `config/ghostty`, AeroSpace, zsh), update it in
+  the same PR.
 - `Brewfile.{basic,common,macos,linux}` — Homebrew bundles, sorted A–Z per
   section (`check_brewfile_sort.sh`). Split rule: `basic` = anything the shell
   needs at load time (prompt, completion, plugin manager, eval-cache inlines,

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -68,12 +68,20 @@ Symbols: ⌘ = Command, ⌥ = Option/Alt, ⌃ = Control, ⇧ = Shift
 |-----|--------|
 | ⌘+1~9 | Switch to window 1~9 |
 | ⌘+T (M-t) | New window |
+| ⌥⌘+Left / Right | Previous / next window |
+
+### Sessions (no prefix)
+
+| Key | Action |
+|-----|--------|
+| ⌥⌘+Up / Down | Switch to previous / next session |
 
 ### Panes (no prefix)
 
 | Key | Action |
 |-----|--------|
 | ⌥⌘+h/j/k/l | Select pane left / down / up / right |
+| ⌥+Z (M-z) | Toggle pane zoom (🔍 in window status while zoomed) |
 
 ⌥⌘+hjkl works because Ghostty sends ESC+hjkl (M-hjkl) even with ⌘ held,
 while AeroSpace only intercepts plain ⌥+hjkl.
@@ -87,6 +95,13 @@ while AeroSpace only intercepts plain ⌥+hjkl.
 | prefix + m | Mark pane |
 | prefix + M | Move marked pane here (join-pane) |
 | prefix + Space | Cycle layout |
+| prefix + r | Reload ~/.tmux.conf |
+| prefix + e | Toggle synchronize-panes (⚠ SYNC in status-right while on) |
+| prefix + b | Toggle status bar (screen sharing) |
+| prefix + g | lazygit in a popup (floating pane on tmux 3.7+) |
+| prefix + t | Throwaway shell in a popup (floating pane on tmux 3.7+; replaces clock-mode) |
+| prefix + f | fzf switcher across all sessions/windows with live preview (replaces find-window) |
+| prefix + * | New floating pane (tmux 3.7+ default binding) |
 
 ### Copy mode (vi)
 


### PR DESCRIPTION
## Summary

Bring KEYBINDINGS.md up to date with the tmux bindings added in #101 (plus two pre-existing undocumented ones), and make AGENTS.md point AI assistants at KEYBINDINGS.md so future keybinding changes update it in the same PR.

## Changes

- `KEYBINDINGS.md` — tmux section: add ⌥⌘+←/→ (window prev/next) and a new Sessions table for ⌥⌘+↑/↓ (both existed but were undocumented); ⌥+Z zoom toggle; prefix r/e/b/g/t/f rows; prefix+* (tmux 3.7 default floating pane)
- `AGENTS.md` — add KEYBINDINGS.md to the repository map with the rule that any keybinding change updates it in the same PR (CLAUDE.md is a symlink to AGENTS.md, so this reaches all assistants)

## Verification

- Cross-checked every documented bind against the current `.tmux.conf`
- Note: the "floating pane on tmux 3.7+" annotation on the prefix+g/t rows describes #108 — merge #108 first (or together)
- lefthook pre-commit/commit-msg hooks passed (editorconfig, gitleaks)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #101, depends on #108 (merge #108 first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN

---
_Generated by [Claude Code](https://claude.ai/code/session_017JFaz3iNg6NiSW9oZGWTpN)_