### PR TITLE
docs(keybindings): add nvim section, fill gaps, point configs here

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,3 +1,5 @@
+# NOTE: keybindings in this file are documented in KEYBINDINGS.md (repo
+# root) — update it when adding or changing a binding.
 set-option -g prefix C-t
 bind C-t send-prefix
 unbind-key C-b

--- a/.zshrc
+++ b/.zshrc
@@ -251,6 +251,8 @@ alias gist='gh gist create --web'
 #=====================
 # keybindings
 #=====================
+# NOTE: keybindings in this file (also ^G / ^X^N defined near their widgets)
+# are documented in KEYBINDINGS.md (repo root) — update it when they change.
 bindkey "^\\" undo
 
 #=====================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@ truth, so the two never diverge.
 - `config/` — XDG configs symlinked to `~/.config` (nvim, ghostty, starship, …).
 - Root dotfiles — `.zshrc`, `.tmux.conf`, `.vimrc`, `.gitconfig`, … into `$HOME`.
 - `KEYBINDINGS.md` — layered keybinding reference (macOS → AeroSpace → Ghostty →
-  tmux → zsh; upper layers intercept first). When you add, remove, or rebind a
-  key anywhere (`.tmux.conf`, `config/ghostty`, AeroSpace, zsh), update it in
-  the same PR.
+  tmux → zsh → nvim; upper layers intercept first). When you add, remove, or
+  rebind a key anywhere (`.tmux.conf`, `config/ghostty`, AeroSpace, zsh,
+  `config/nvim`), update it in the same PR.
 - `Brewfile.{basic,common,macos,linux}` — Homebrew bundles, sorted A–Z per
   section (`check_brewfile_sort.sh`). Split rule: `basic` = anything the shell
   needs at load time (prompt, completion, plugin manager, eval-cache inlines,

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -2,6 +2,10 @@
 
 Hierarchical keybinding reference. Upper layers intercept keys first.
 
+Sources: AeroSpace (managed outside this repo), `config/ghostty/config`,
+`.tmux.conf`, `.zshrc`, `config/nvim/` — each carries a pointer comment back to
+this file; update this file whenever a binding changes there.
+
 Symbols: ⌘ = Command, ⌥ = Option/Alt, ⌃ = Control, ⇧ = Shift
 
 ---
@@ -52,6 +56,7 @@ Symbols: ⌘ = Command, ⌥ = Option/Alt, ⌃ = Control, ⇧ = Shift
 |-----|--------|
 | F12 | Toggle quick terminal (global) |
 | ⌘+1~9 | → sends ESC+1~9 to tmux (window switching) |
+| ⌘⌥+←/→/↑/↓ | → sends ⌥+arrows to tmux (window / session switching) |
 | ⌘+⇧+O | Toggle background opacity |
 | ¥ | Insert `\` (backslash) |
 
@@ -62,19 +67,14 @@ Symbols: ⌘ = Command, ⌥ = Option/Alt, ⌃ = Control, ⇧ = Shift
 
 ## tmux (prefix: C-t)
 
-### Windows (no prefix)
+### Windows / sessions (no prefix)
 
 | Key | Action |
 |-----|--------|
 | ⌘+1~9 | Switch to window 1~9 |
-| ⌘+T (M-t) | New window |
-| ⌥⌘+Left / Right | Previous / next window |
-
-### Sessions (no prefix)
-
-| Key | Action |
-|-----|--------|
-| ⌥⌘+Up / Down | Switch to previous / next session |
+| ⌥+T (M-t) | New window |
+| ⌥+←/→ (or ⌥⌘+←/→) | Previous / next window |
+| ⌥+↑/↓ (or ⌥⌘+↑/↓) | Switch to previous / next session |
 
 ### Panes (no prefix)
 
@@ -119,9 +119,75 @@ while AeroSpace only intercepts plain ⌥+hjkl.
 | Key | Action |
 |-----|--------|
 | ⌃+R | History search |
+| ⌃+G | livegrep (interactive ripgrep → open in editor) |
+| ⌃+X ⌃+N | navi snippet search → insert into command line |
+| ⌃+\ | Undo |
 | ⌃+A / E | Beginning / end of line |
 | ⌃+W | Delete word backward |
 | ⌃+U | Clear line |
 | ⌃+L | Clear screen |
 | ⌥+B / F | Move word backward / forward |
 | ⌥+D | Delete word forward |
+
+---
+
+## Neovim (leader: Space)
+
+Defined in `config/nvim/init.lua` and `config/nvim/lua/kimoto/plugins/*.lua`.
+
+### Windows / buffers / tools
+
+| Key | Action |
+|-----|--------|
+| ⌃+h/j/k/l | Move between windows |
+| Space+1~6 | Go to buffer 1~6 |
+| Space+n / p | Next / previous buffer |
+| Tab / ⇧+Tab | Cycle buffers (bufferline) |
+| Space+e | Toggle file tree (nvim-tree) |
+| Space+t | Toggle terminal (toggleterm) |
+| ⌃+Space | Normal mode: toggle terminal / insert mode: trigger completion |
+
+### Telescope
+
+| Key | Action |
+|-----|--------|
+| Space+ff | Find files |
+| Space+fg | Live grep |
+| Space+fb | Buffers |
+| Space+fh | Help tags |
+| Space+fr | Frecency (recent files) |
+
+### LSP / completion
+
+| Key | Action |
+|-----|--------|
+| gd / gy / gi | Definition / type definition / implementation |
+| grn / gra / grr | Rename / code action / references (nvim builtin) |
+| K | Hover (nvim builtin) |
+| Enter (insert) | Confirm completion (nvim-cmp) |
+
+### Yank ring (yanky)
+
+| Key | Action |
+|-----|--------|
+| p / P / gp / gP | Put (ring-aware) |
+| ⌃+p / ⌃+n | Cycle older / newer yank after a put |
+
+### Debug (nvim-dap)
+
+| Key | Action |
+|-----|--------|
+| F5 | Continue |
+| F9 | Toggle breakpoint |
+| F10 / F11 / ⇧+F11 | Step over / into / out |
+| Space+d | Toggle dap-ui |
+| Space+dr / Space+dl | Open REPL / run last |
+| Space+lp | Set log point |
+
+### Plugin defaults worth knowing
+
+| Key | Action |
+|-----|--------|
+| gcc / gc{motion} | Toggle comment (Comment.nvim) |
+| ys / cs / ds | Add / change / delete surround (vim-surround) |
+| Space+j | Jump to definition (any-jump) |

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -8,6 +8,8 @@ font-thicken-strength = 10
 macos-option-as-alt = true
 macos-titlebar-style = hidden
 quick-terminal-animation-duration = 1000
+# NOTE: keybindings in this file are documented in KEYBINDINGS.md (repo
+# root) — update it when adding or changing a binding.
 keybind = global:f12=toggle_quick_terminal
 keybind = ¥=text:\\
 keybind = super+digit_1=text:\x1b1

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,3 +1,6 @@
+-- NOTE: keybindings defined in this config (and lua/kimoto/plugins/*.lua) are
+-- documented in KEYBINDINGS.md at the repo root — update it when adding or
+-- changing a map.
 require('kimoto/basic_config')
 require('kimoto/setup_plugin')
 require('kimoto/plugins/lualine')

--- a/config/nvim/lua/kimoto/plugins/bufferline.lua
+++ b/config/nvim/lua/kimoto/plugins/bufferline.lua
@@ -11,5 +11,7 @@ require'bufferline'.setup({
   -- no custom highlights: derive colors from the active colorscheme (onedark)
 })
 
+-- NOTE: keybindings here are documented in KEYBINDINGS.md (repo root) —
+-- update it when adding or changing a map.
 vim.keymap.set('n', '<Tab>', '<Cmd>BufferLineCycleNext<CR>', {})
 vim.keymap.set('n', '<S-Tab>', '<Cmd>BufferLineCyclePrev<CR>', {})

--- a/config/nvim/lua/kimoto/plugins/lsp.lua
+++ b/config/nvim/lua/kimoto/plugins/lsp.lua
@@ -4,6 +4,8 @@
 -- coc-prettier used to own, and the eslint language server replaces
 -- coc-eslint. Builtin LSP maps (0.11+): grn=rename, gra=code action,
 -- grr=references, K=hover; gd/gy/gi are added below.
+-- NOTE: keybindings here are documented in KEYBINDINGS.md (repo root) —
+-- update it when adding or changing a map.
 
 -- Servers mirroring the old coc extensions. mason-lspconfig auto-installs
 -- missing ones on startup (first-run bootstrap); enabling a server that is

--- a/config/nvim/lua/kimoto/plugins/toggleterm.lua
+++ b/config/nvim/lua/kimoto/plugins/toggleterm.lua
@@ -1,3 +1,5 @@
+-- NOTE: keybindings here are documented in KEYBINDINGS.md (repo root) —
+-- update it when adding or changing a map.
 require("toggleterm").setup{
   size = 30,
   direction = 'horizontal',


### PR DESCRIPTION
## Summary

Follow-up to #106 and #110: document the Neovim keybindings (KEYBINDINGS.md had no nvim section at all), fill remaining gaps in the zsh/Ghostty sections, and put pointer comments in every config file that defines keybindings so the doc stays in sync. Rebased on top of #110's tmux additions — where the two overlapped, #110's richer wording won.

## Changes

- **KEYBINDINGS.md**
  - new Neovim section (leader = Space): window/buffer navigation, telescope, LSP/completion (`gd`/`gy`/`gi` + builtin `grn`/`gra`/`grr`/`K`), yanky ring, nvim-dap, bufferline/toggleterm, and notable plugin defaults (`gcc`, `ys`/`cs`/`ds`, `Space+j`)
  - zsh: add `⌃+G` (livegrep), `⌃+X ⌃+N` (navi snippet), `⌃+\` (undo)
  - Ghostty: add the `⌘⌥+arrows` → `⌥+arrows` translation row
  - tmux: note the plain `⌥+arrow` variants that work alongside `⌘⌥+arrows` (option-as-alt)
  - fix: new window is `⌥+T` (M-t), not `⌘+T` — Ghostty has no `super+t` bind, so `⌘+T` never reaches tmux
  - header now lists the source files this doc mirrors
- **Pointer comments** in `.tmux.conf`, `.zshrc`, `config/ghostty/config`, `config/nvim/init.lua`, and `config/nvim/lua/kimoto/plugins/{lsp,bufferline,toggleterm}.lua`: keybindings here are documented in KEYBINDINGS.md — update it when they change
- **AGENTS.md**: extend #110's `KEYBINDINGS.md` entry with nvim in the layer list and `config/nvim` in the update rule (no duplicate rule added)

## Verification

- Every table entry cross-checked against the actual definitions in `.tmux.conf`, `.zshrc`, `config/ghostty/config`, and `config/nvim/`
- The `⌥+T` fix verified against `config/ghostty/config` (no `super+t` keybind exists; `macos-option-as-alt` sends ESC+t)
- Comment-only changes to executable configs: `lint_zsh.sh`, `lint_lua.sh`, `lint_editorconfig.sh` and the lefthook pre-commit suite pass; nvim e2e (`ci_nvim_loading_test.sh`) passes locally

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

refs #106, #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfWwzDBCR3Ky8FkbvNJwHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfWwzDBCR3Ky8FkbvNJwHy)_