### PR TITLE
fix(bin): stop startup reminders from nagging after they're resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ mysqlsh/*
 .zcompdump*
 
 # local-only (machine-specific / editor state)
+.vim/.netrwhist
 .vim/undodir/
 .zshrc.local
 

--- a/.vimrc
+++ b/.vimrc
@@ -32,6 +32,9 @@ set backup
 set backupdir=~/tmp
 set directory=~/tmp
 
+" netrwの閲覧履歴(~/.vim/.netrwhist)を書き出さない
+let g:netrw_dirhistmax = 0
+
 " 日本語設定
 set termencoding=utf8
 set encoding=utf8

--- a/bin/brew_bundle_check.sh
+++ b/bin/brew_bundle_check.sh
@@ -9,10 +9,12 @@
 #
 # `brew bundle check` is comparatively slow, so startup never waits for it: the
 # foreground only prints the cached result of the previous check, then a
-# detached background job refreshes the cache (at most once per 24h, or sooner
-# when a Brewfile or the Homebrew Cellar changed). The warning can therefore be
-# one shell stale — the same trade-off dotfiles_sync_check.sh makes for its
-# background `git fetch`.
+# detached background job refreshes the cache. An "all satisfied" result is
+# trusted for 24h (or until a Brewfile, the Cellar, or the Caskroom changes),
+# but a pending warning is re-checked every startup, so installing the missing
+# packages clears the nag on the next shell instead of when the 24h throttle
+# expires. The warning can therefore be one shell stale — the same trade-off
+# dotfiles_sync_check.sh makes for its background `git fetch`.
 #
 # Skipped entirely when DOTFILES_NO_BREW_CHECK is set (used by CI so the load
 # test neither slows down nor prints reminder noise).
@@ -60,9 +62,11 @@ fi
 # All fds are detached so neither the terminal nor the caller (zsh startup, or
 # bats' fd 3) ever waits on this job.
 (
-    # Re-run the (slow) check at most once per 24h.
+    # Re-run the (slow) check at most once per 24h — but only trust a cached
+    # "all satisfied" result. A pending warning is re-checked every startup so
+    # acting on it clears the nag on the next shell.
     need_check=1
-    if [ -f "$stamp" ] && [ -f "$result" ]; then
+    if [ -f "$stamp" ] && [ -f "$result" ] && [ ! -s "$result" ]; then
         last=$(cat "$stamp" 2>/dev/null || echo 0)
         case "$last" in
             '' | *[!0-9]*) last=0 ;;
@@ -72,11 +76,12 @@ fi
         fi
     fi
 
-    # Invalidate the cache if any Brewfile or the Homebrew Cellar changed since
-    # the last check.
+    # Invalidate the cache if any Brewfile, the Homebrew Cellar, or the
+    # Caskroom changed since the last check.
     if [ "$need_check" -eq 0 ]; then
         cellar=$(brew --cellar 2>/dev/null) || cellar=""
-        for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"}; do
+        caskroom=$(brew --caskroom 2>/dev/null) || caskroom=""
+        for check_path in "${files[@]/#/$REPO_DIR/}" ${cellar:+"$cellar"} ${caskroom:+"$caskroom"}; do
             [ -e "$check_path" ] || continue
             mtime=$(stat -c %Y "$check_path" 2>/dev/null || stat -f %m "$check_path" 2>/dev/null || echo 0)
             if [ "$mtime" -gt "$last" ]; then

--- a/test/brew_bundle_check.bats
+++ b/test/brew_bundle_check.bats
@@ -103,15 +103,29 @@ wait_for() {
   [[ "$output" == *"brew bundle install --file="* ]]
 }
 
-@test "reuses the cached nag within 24h without re-checking" {
-  BREW_CHECK_RC=1 run "$SCRIPT"
+@test "a pending nag is re-checked every startup and clears once satisfied" {
+  BREW_CHECK_RC=1 run "$SCRIPT" # seed a "missing" cache
   wait_for '[ -s "$CACHE/brew_missing" ]'
-  # Within 24h the stub flipping to "satisfied" must NOT change the cached nag.
+
+  # Bundles are satisfied now: this shell still shows the cached nag, but the
+  # background re-check runs despite the fresh 24h stamp and clears it.
   BREW_CHECK_RC=0 run "$SCRIPT"
   [[ "$output" == *"Brewfile.basic"* ]]
-  # Give a rogue background re-check time to clear the cache; it must not have.
+  wait_for '[ ! -s "$CACHE/brew_missing" ]'
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  [ -z "$output" ]
+}
+
+@test "trusts a satisfied cache for 24h without re-checking" {
+  BREW_CHECK_RC=0 run "$SCRIPT"
+  wait_for '[ -f "$CACHE/brew_missing" ]'
+  [ ! -s "$CACHE/brew_missing" ]
+  # Within 24h the stub flipping to "missing" must NOT repopulate the cache.
+  BREW_CHECK_RC=1 run "$SCRIPT"
+  [ -z "$output" ]
+  # Give a rogue background re-check time to write the cache; it must not have.
   sleep 1
-  [ -s "$CACHE/brew_missing" ]
+  [ ! -s "$CACHE/brew_missing" ]
 }
 
 @test "re-checks in the background once the stamp is older than 24h" {


### PR DESCRIPTION
## Summary

Startup reminders could keep nagging long after being resolved: a `[brew]` warning stayed cached for up to 24h after the packages were installed, and the `[dotfiles] uncommitted changes` warning was effectively permanent because vim's netrw kept recreating `.vim/.netrwhist` inside the repo. This PR makes a resolved warning clear on the next shell and stops netrw from dirtying the repo.

## Changes

- `bin/brew_bundle_check.sh`: trust the cached result for 24h only while it is "all satisfied"; a pending warning is re-checked in the background on every startup, so acting on it clears the nag on the next shell instead of when the throttle expires.
- `bin/brew_bundle_check.sh`: watch the Caskroom mtime as well as the Cellar for cache invalidation — cask installs never touch the Cellar.
- `.vimrc`: set `g:netrw_dirhistmax = 0` so netrw stops writing `.vim/.netrwhist`.
- `.gitignore`: ignore `.vim/.netrwhist` so a stray history file from an older vim never dirties the repo again.
- `test/brew_bundle_check.bats`: replace the "reuses the cached nag within 24h" test with "a pending nag is re-checked every startup and clears once satisfied", and add "trusts a satisfied cache for 24h without re-checking" to keep the throttle covered.

## Verification

- TDD: added the new bats test first and confirmed it fails against the old script (background re-check never ran within 24h), then applied the fix and confirmed `bats test/brew_bundle_check.bats` passes (9/9).
- End-to-end on the real machine: with the actual stale `~/.cache/dotfiles/brew_missing` (listing `Brewfile.common`, already satisfied), the first run printed the cached nag, the background re-check cleared the cache despite the fresh 24h stamp, and the second run was silent.
- `./bin/lint_shell.sh`, `./bin/lint_bash.sh`, `./bin/lint_editorconfig.sh` clean; full pre-commit suite (131 bats tests) green via lefthook.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
