### PR TITLE
feat(tmux): make prefix+f fzf switcher pane-granular

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -67,9 +67,9 @@ bind-key t display-popup -E -w 80% -h 75% -d "#{pane_current_path}"
 if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- $v; [ "$1" -gt 3 ] || { [ "$1" -eq 3 ] && [ "$2" -ge 7 ]; }' \
   'bind-key g new-pane -c "#{pane_current_path}" lazygit; bind-key t new-pane -c "#{pane_current_path}"'
 
-# f = fzf switcher across every window of every session, with a live pane
-# preview (replaces the default find-window)
-bind-key f display-popup -E -w 90% -h 70% 'tmux list-windows -a -F "#S:#I  #W" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
+# f = fzf switcher across every pane of every session, with a live preview
+# (replaces the default find-window); switch-client accepts a pane target
+bind-key f display-popup -E -w 90% -h 70% 'tmux list-panes -a -F "#S:#I.#P  #W  #{pane_current_command}" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
 
 # toggle the status bar (handy for screen sharing)
 bind-key b set-option status

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -100,7 +100,7 @@ while AeroSpace only intercepts plain ⌥+hjkl.
 | prefix + b | Toggle status bar (screen sharing) |
 | prefix + g | lazygit in a popup (floating pane on tmux 3.7+) |
 | prefix + t | Throwaway shell in a popup (floating pane on tmux 3.7+; replaces clock-mode) |
-| prefix + f | fzf switcher across all sessions/windows with live preview (replaces find-window) |
+| prefix + f | fzf switcher across all panes of all sessions with live preview (replaces find-window) |
 | prefix + * | New floating pane (tmux 3.7+ default binding) |
 
 ### Copy mode (vi)


### PR DESCRIPTION
## Summary

Make the `prefix + f` fzf switcher pane-granular: it now lists every pane of every session (instead of windows) so you can jump straight to a specific pane.

## Changes

- `.tmux.conf`: `prefix + f` popup now feeds `list-panes -a` (format `#S:#I.#P  #W  #{pane_current_command}`) into fzf; `switch-client -t` accepts the pane target and switches session, window and pane in one go
- `KEYBINDINGS.md`: update the `prefix + f` description to match

## Verification

- `./bin/ci_tmux_loading_test.sh` → PASS (loads without config errors, 729ms < 1000ms budget)
- Verified the pipeline on the live tmux server: `list-panes -a` output format, `${sel%%  *}` target extraction, and `capture-pane -ep -t <target>` preview all work
- `man tmux` (3.7b) confirms `switch-client -t` treats a target containing `:` / `.` as a pane and changes session, window and pane

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
