### PR TITLE
fix(tmux): show pane titles in the prefix+f fzf switcher

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -68,8 +68,10 @@ if-shell 'v=$(tmux -V | sed -En "s/^tmux ([0-9]+)\.([0-9]+).*/\1 \2/p"); set -- 
   'bind-key g new-pane -c "#{pane_current_path}" lazygit; bind-key t new-pane -c "#{pane_current_path}"'
 
 # f = fzf switcher across every pane of every session, with a live preview
-# (replaces the default find-window); switch-client accepts a pane target
-bind-key f display-popup -E -w 90% -h 70% 'tmux list-panes -a -F "#S:#I.#P  #W  #{pane_current_command}" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
+# (replaces the default find-window); switch-client accepts a pane target.
+# Label: pane title, falling back to the pane's cwd while the title is still
+# the default hostname (no program has set one)
+bind-key f display-popup -E -w 90% -h 70% 'tmux list-panes -a -F "#S:#I.#P  #W  #{?#{||:#{==:#{pane_title},#{host}},#{==:#{pane_title},#{host_short}}},#{b:pane_current_path},#{pane_title}}" | fzf --reverse --prompt="switch> " --preview "tmux capture-pane -ep -t {1}" --preview-window "right,60%" | { read -r sel; [ -n "$sel" ] && tmux switch-client -t "${sel%%  *}"; }'
 
 # toggle the status bar (handy for screen sharing)
 bind-key b set-option status


### PR DESCRIPTION
## Summary

Show pane titles in the `prefix + f` fzf pane switcher. The previous label used `#{pane_current_command}`, which renders as an unhelpful process name, while `#{pane_title}` carries the meaningful title programs set (e.g. Claude Code session titles).

## Changes

- `.tmux.conf`: replace `#{pane_current_command}` in the switcher's list format with `#{pane_title}`, falling back to `#{b:pane_current_path}` while the title is still the default hostname (compared against both `#{host}` and `#{host_short}`)

## Verification

- Ran the new `list-panes -a -F ...` format on the live server: titled panes show their titles, a fresh untitled pane falls back to its cwd basename
- `TMUX_CONF=$PWD/.tmux.conf ./bin/ci_tmux_loading_test.sh` → PASS (loads without config errors, 855ms < 1000ms budget)

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

Follow-up to #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
