### PR TITLE
chore: zsh abbr, mise go, tmux prefix indicator tweaks

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -132,7 +132,7 @@ set -g message-style "bg=#073642,fg=#2aa198"
 set -g message-command-style "bg=#073642,fg=#2aa198"
 set -g status-left-length 50
 set -g status-right-length 100
-set -g status-left "#[fg=#002b36,bg=#268bd2,bold] #(tmux list-sessions -F '##{?session_attached,#[fg=#fdf6e3]#[bg=#268bd2]●,#[fg=#002b36]#[bg=#268bd2]•}' | tr -d '\n') #{?client_prefix,#[bg=#b58900],}#{session_name}#[bg=#268bd2] #[fg=#268bd2,bg=#073642,nobold] "
+set -g status-left "#[fg=#002b36,bg=#{?client_prefix,#b58900,#268bd2},bold] #(tmux list-sessions -F '##{?session_attached,#[fg=#fdf6e3]●,#[fg=#002b36]•}' | tr -d '\n') #{session_name} #[fg=#{?client_prefix,#b58900,#268bd2},bg=#073642,nobold] "
 set -g status-right "#{?pane_synchronized,#[fg=#dc322f bg=#073642 bold]⚠ SYNC #[nobold],}#[fg=#859900,bg=#073642]#[fg=#002b36,bg=#859900,bold] ⎈ #(kubectl config current-context 2>/dev/null) #[fg=#268bd2,bg=#859900]#[fg=#002b36,bg=#268bd2,bold] %F %R "
 # Claude Code state indicator: bin/claude_tmux_indicator.sh tags panes with
 # @claude_state (waiting=red #dc322f, done=yellow #b58900, red wins); the

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,5 +1,6 @@
 [tools]
 bun = "latest"
+go = "latest"
 node = "latest"
 rust = "latest"
 

--- a/config/zsh/abbr.zsh
+++ b/config/zsh/abbr.zsh
@@ -27,7 +27,12 @@ typeset -gA ABBR_MAP=(
 
 _abbr_expand() {
   local word=${LBUFFER##*[[:space:]]}
-  [[ -n $word && -n ${ABBR_MAP[$word]} ]] && LBUFFER[-${#word},-1]=${ABBR_MAP[$word]}
+  [[ -n $word && -n ${ABBR_MAP[$word]} ]] || return 0
+  local prefix=${LBUFFER%"$word"}
+  # command position only, like zsh-abbr: line start or right after ; & | ( `
+  # (so `git co` keeps its literal `co` instead of expanding mid-line)
+  [[ $prefix =~ '(^|[;&|(`])[[:space:]]*$' ]] || return 0
+  LBUFFER=${prefix}${ABBR_MAP[$word]}
 }
 
 _abbr_expand_space() {


### PR DESCRIPTION
## Summary

Three small independent tweaks: fix the zsh abbreviation expansion firing outside command position, add go to the mise global tools, and make the tmux prefix indicator color the whole status-left segment.

## Changes

- `config/zsh/abbr.zsh`: expand abbreviations only in command position (line start or right after `; & | (` and backtick), like zsh-abbr, and rebuild `LBUFFER` from the prefix instead of assigning through a negative subscript. Previously `git co ` mangled the buffer into `git git checkout`.
- `config/mise/config.toml`: add `go` to global tools.
- `.tmux.conf`: on prefix (`C-t`), the status-left highlight only recolored the session name, leaving the session dots, padding, and powerline arrow blue. Switch the segment background and arrow foreground together via a `#{?client_prefix,...}` conditional, and let the dots inherit the segment background.

## Verification

- tmux: applied the new `status-left` to the running server, checked `#{T:status-left}` expansion (all blue when idle) and visually confirmed the whole segment turns yellow while `C-t` is held.
- zsh / mise: none beyond CI (zsh startup test covers `abbr.zsh` loading).

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
