### PR TITLE
fix(zsh): point SSL_CERT_FILE at the CA bundle on Linux

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -199,6 +199,21 @@ export XDG_CONFIG_HOME="$HOME/.config"
 export GPG_TTY=$TTY # zsh sets $TTY itself; saves a tty(1) fork per shell
 # carapace: fall back to zsh's native completions for commands it has no spec for
 export CARAPACE_BRIDGES='zsh,bash'
+# mise (and other rustls-based tools) probe every file in the system CA cert
+# dirs individually rather than reading one bundle; a root-only leaf cert
+# dropped in there (e.g. this host's Passenger localhost.crt) trips a
+# permission-denied WARN on every mise hook. Pointing SSL_CERT_FILE at the
+# actual bundle skips that per-file directory scan.
+if [[ $OSTYPE == linux* ]]; then
+  for _ca_bundle in /etc/ssl/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt \
+      /etc/ssl/certs/ca-certificates.crt; do
+    if [[ -r "$_ca_bundle" ]]; then
+      export SSL_CERT_FILE="$_ca_bundle"
+      break
+    fi
+  done
+  unset _ca_bundle
+fi
 
 #=====================
 # completion zstyles


### PR DESCRIPTION
## Summary

mise emits a `WARN Error loading CA root certificate: ... Permission denied` on this sakura VPS. It probes every file in the system CA cert dirs individually rather than reading one bundle, and trips on a root-only leaf cert (`localhost.crt`, Passenger's self-signed cert) sitting in that same directory. Pointing `SSL_CERT_FILE` at the actual bundle file skips the per-file directory scan and silences the warning.

## Changes

- `.zshrc`: on Linux, export `SSL_CERT_FILE` to the first readable CA bundle among the common paths (`/etc/ssl/certs/ca-bundle.crt`, `/etc/pki/tls/certs/ca-bundle.crt`, `/etc/ssl/certs/ca-certificates.crt`), if one exists.

## Verification

- `SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt mise --version` no longer prints the CA cert WARN (only the unrelated "new version available" notice remains).
- Confirmed a fresh interactive zsh sets `SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt` on this host.
- `./bin/lint_zsh.sh` passes.
- `./bin/ci_zsh_loading_test.sh` has a pre-existing, unrelated `ls function` failure on `main` too (reproduced identically before this change) — not introduced by this PR.

## Checklist

- [x] Branched off `main` — no direct commits to `main`
- [x] Commit subjects follow Conventional Commits
- [x] No secrets / sensitive files committed (gitleaks clean)

## Related

none